### PR TITLE
util: add dump metadata command

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -661,6 +661,20 @@ void ZenFS::EncodeSnapshotTo(std::string* output) {
   PutLengthPrefixedSlice(output, Slice(files_string));
 }
 
+void ZenFS::EncodeJson(std::stringstream& json_stream) {
+  bool first_element = true;
+  json_stream << "{\"files\":[";
+  for (const auto& file : files_) {
+    if (first_element) {
+      first_element = false;
+    } else {
+      json_stream << ",";
+    }
+    file.second->EncodeJson(json_stream);
+  }
+  json_stream << "]}";
+}
+
 Status ZenFS::DecodeFileUpdateFrom(Slice* slice) {
   ZoneFile* update = new ZoneFile(zbd_, "not_set", 0);
   uint64_t id;

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -174,6 +174,8 @@ class ZenFS : public FileSystemWrapper {
     return "ZenFS - The Zoned-enabled File System";
   }
 
+  void EncodeJson(std::stringstream& json_stream);
+
   virtual IOStatus NewSequentialFile(const std::string& fname,
                                      const FileOptions& file_opts,
                                      std::unique_ptr<FSSequentialFile>* result,

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -43,6 +43,14 @@ void ZoneExtent::EncodeTo(std::string* output) {
   PutFixed32(output, length_);
 }
 
+void ZoneExtent::EncodeJson(std::stringstream& json_stream) {
+  json_stream << "{";
+  json_stream << "\"start\":" << start_ << ",";
+  json_stream << "\"length\":" << length_ << ",";
+  json_stream << "\"zone_start\":" << zone_->start_;
+  json_stream << "}";
+}
+
 enum ZoneFileTag : uint32_t {
   kFileID = 1,
   kFileName = 2,
@@ -77,6 +85,26 @@ void ZoneFile::EncodeTo(std::string* output, uint32_t extent_start) {
   PutFixed64(output, (uint64_t)m_time_);
   /* We're not encoding active zone and extent start
    * as files will always be read-only after mount */
+}
+
+void ZoneFile::EncodeJson(std::stringstream& json_stream) {
+  json_stream << "{";
+  json_stream << "\"id\":" << file_id_ << ",";
+  json_stream << "\"filename\":\"" << filename_ << "\",";
+  json_stream << "\"size\":" << fileSize << ",";
+  json_stream << "\"hint\":" << lifetime_ << ",";
+  json_stream << "\"extents\":[";
+
+  bool first_element = true;
+  for (ZoneExtent* extent : extents_) {
+    if (first_element) {
+      first_element = false;
+    } else {
+      json_stream << ",";
+    }
+    extent->EncodeJson(json_stream);
+  }
+  json_stream << "]}";
 }
 
 Status ZoneFile::DecodeFrom(Slice* input) {

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -34,6 +35,7 @@ class ZoneExtent {
   explicit ZoneExtent(uint64_t start, uint32_t length, Zone* zone);
   Status DecodeFrom(Slice* input);
   void EncodeTo(std::string* output);
+  void EncodeJson(std::stringstream& json_stream);
 };
 
 class ZoneFile {
@@ -86,6 +88,7 @@ class ZoneFile {
     EncodeTo(output, nr_synced_extents_);
   };
   void EncodeSnapshotTo(std::string* output) { EncodeTo(output, 0); };
+  void EncodeJson(std::stringstream& json_stream);
   void MetadataSynced() { nr_synced_extents_ = extents_.size(); };
 
   Status DecodeFrom(Slice* input);

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <fstream>
 #include <streambuf>
+#include <sstream>
 
 #include <rocksdb/file_system.h>
 #include <rocksdb/plugin/zenfs/fs/fs_zenfs.h>
@@ -395,6 +396,28 @@ int zenfs_tool_restore() {
 
   return 0;
 }
+
+int zenfs_tool_dump() {
+  Status s;
+  ZonedBlockDevice *zbd = zbd_open(true);
+  if (zbd == nullptr) return 1;
+
+  ZenFS *zenFS;
+  s = zenfs_mount(zbd, &zenFS, true);
+  if (!s.ok()) {
+    fprintf(stderr, "Failed to mount filesystem, error: %s\n",
+            s.ToString().c_str());
+    return 1;
+  }
+
+  std::stringstream json_stream;
+  zenFS->EncodeJson(json_stream);
+
+  fprintf(stdout, "%s\n", json_stream.str().c_str());
+
+  return 0;
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char **argv) {
@@ -424,6 +447,8 @@ int main(int argc, char **argv) {
     return ROCKSDB_NAMESPACE::zenfs_tool_backup();
   } else if (subcmd == "restore") {
     return ROCKSDB_NAMESPACE::zenfs_tool_restore();
+  } else if (subcmd == "dump") {
+    return ROCKSDB_NAMESPACE::zenfs_tool_dump();
   } else {
     fprintf(stderr, "Subcommand not recognized: %s\n", subcmd.c_str());
     return 1;


### PR DESCRIPTION
This PR adds dump metadata command. This command will dump all files and extents in json format. After this PR is merged, we will add tools to analyze the metadata.

```json
{
    "files": [
        {
            "id": 4,
            "filename": "test_db/000003.log",
            "size": 254886023,
            "hint": 2,
            "extents": [
                {
                    "start": 8589934592,
                    "length": 4159,
                    "zone_start": 8589934592
                },
                {
                    "start": 8589942784,
                    "length": 4159,
                    "zone_start": 8589934592
                },
                {
                    "start": 8589950976,
                    "length": 4159,
                    "zone_start": 8589934592
                },
                {
                    "start": 8589959168,
                    "length": 4159,
                    "zone_start": 8589934592
                },
```
