### PR TITLE
fs: add statistics

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -1037,6 +1037,45 @@ std::map<std::string, Env::WriteLifeTimeHint> ZenFS::GetWriteLifeTimeHints() {
   return hint_map;
 }
 
+std::vector<ZoneStat> ZenFS::GetStat() {
+  // Store size of each file_id in each zone
+  std::map<uint64_t, std::map<uint64_t, uint64_t>> sizes;
+  // Store file_id to filename map
+  std::map<uint64_t, std::string> filenames;
+
+  files_mtx_.lock();
+
+  for (auto& file_it : files_) {
+    ZoneFile* file = file_it.second;
+    uint64_t file_id = file->GetID();
+    filenames[file_id] = file->GetFilename();
+    for (ZoneExtent* extent : file->GetExtents()) {
+      uint64_t zone_fake_id = extent->zone_->start_;
+      sizes[zone_fake_id][file_id] += extent->length_;
+    }
+  }
+
+  files_mtx_.unlock();
+
+  // Final result vector
+  std::vector<ZoneStat> stat = zbd_->GetStat();
+
+  for (auto& zone : stat) {
+    std::map<uint64_t, uint64_t>& zone_files = sizes[zone.start_position];
+    for (auto& file : zone_files) {
+      uint64_t file_id = file.first;
+      uint64_t file_length = file.second;
+      ZoneFileStat file_stat;
+      file_stat.file_id = file_id;
+      file_stat.size_in_zone = file_length;
+      file_stat.filename = filenames[file_id];
+      zone.files.emplace_back(std::move(file_stat));
+    }
+  }
+
+  return stat;
+};
+
 #ifndef NDEBUG
 static std::string GetLogFilename(std::string bdev) {
   std::ostringstream ss;

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -9,6 +9,7 @@
 #include "io_zenfs.h"
 #include "rocksdb/env.h"
 #include "rocksdb/file_system.h"
+#include "rocksdb/plugin/zenfs/fs/zbd_stat.h"
 #include "rocksdb/status.h"
 #include "zbd_zenfs.h"
 
@@ -344,6 +345,8 @@ class ZenFS : public FileSystemWrapper {
                                 IODebugContext* /*dbg*/) override {
     return IOStatus::NotSupported("AreFilesSame is not supported in ZenFS");
   }
+
+  std::vector<ZoneStat> GetStat();
 };
 #endif  // !defined(ROCKSDB_LITE) && defined(OS_LINUX)
 

--- a/fs/zbd_stat.h
+++ b/fs/zbd_stat.h
@@ -8,22 +8,8 @@
 
 #if !defined(ROCKSDB_LITE) && defined(OS_LINUX)
 
-#include <errno.h>
-#include <libzbd/zbd.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
-#include <unistd.h>
-
-#include <atomic>
-#include <condition_variable>
-#include <mutex>
 #include <string>
-#include <utility>
 #include <vector>
-
-#include "rocksdb/env.h"
-#include "rocksdb/io_status.h"
 
 namespace ROCKSDB_NAMESPACE {
 

--- a/fs/zbd_stat.h
+++ b/fs/zbd_stat.h
@@ -1,0 +1,47 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+// Copyright (c) 2019-present, Western Digital Corporation
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#if !defined(ROCKSDB_LITE) && defined(OS_LINUX)
+
+#include <errno.h>
+#include <libzbd/zbd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rocksdb/env.h"
+#include "rocksdb/io_status.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class ZoneFileStat {
+ public:
+  uint64_t file_id;
+  uint64_t size_in_zone;
+  std::string filename;
+};
+
+class ZoneStat {
+ public:
+  uint64_t total_capacity;
+  uint64_t write_position;
+  uint64_t start_position;
+  std::vector<ZoneFileStat> files;
+};
+
+}  // namespace ROCKSDB_NAMESPACE
+
+#endif  // !defined(ROCKSDB_LITE) && defined(OS_LINUX)

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -174,6 +174,18 @@ Zone *ZonedBlockDevice::GetIOZone(uint64_t offset) {
   return nullptr;
 }
 
+std::vector<ZoneStat> ZonedBlockDevice::GetStat() {
+  std::vector<ZoneStat> stat;
+  for (const auto z : io_zones) {
+    ZoneStat zone_stat;
+    zone_stat.total_capacity = z->max_capacity_;
+    zone_stat.write_position = z->wp_;
+    zone_stat.start_position = z->start_;
+    stat.emplace_back(std::move(zone_stat));
+  }
+  return stat;
+}
+
 ZonedBlockDevice::ZonedBlockDevice(std::string bdevname,
                                    std::shared_ptr<Logger> logger)
     : filename_("/dev/" + bdevname), logger_(logger) {

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -25,6 +25,7 @@
 
 #include "rocksdb/env.h"
 #include "rocksdb/io_status.h"
+#include "rocksdb/plugin/zenfs/fs/zbd_stat.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -125,6 +126,8 @@ class ZonedBlockDevice {
   void NotifyIOZoneClosed();
 
   void EncodeJson(std::stringstream &json_stream);
+
+  std::vector<ZoneStat> GetStat();
 
  private:
   std::string ErrorToString(int err);

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -186,6 +186,34 @@ int zenfs_tool_df() {
   return 0;
 }
 
+
+int zenfs_tool_stat() {
+  Status s;
+  ZonedBlockDevice *zbd = zbd_open(true);
+  if (zbd == nullptr) return 1;
+
+  ZenFS *zenFS;
+  s = zenfs_mount(zbd, &zenFS, true);
+  if (!s.ok()) {
+    fprintf(stderr, "Failed to mount filesystem, error: %s\n",
+            s.ToString().c_str());
+    return 1;
+  }
+  auto stat = zenFS->GetStat();
+
+  for (auto &&zone : stat) {
+    std::cout << "Zone total=" << zone.total_capacity
+              << " write_position=" << zone.write_position
+              << " start_position=" << zone.start_position << std::endl;
+    for (auto &&file : zone.files) {
+      std::cout << "  [" << file.file_id << "] " << file.filename << " "
+                << file.size_in_zone << std::endl;
+    }
+  }
+
+  return 0;
+}
+
 int zenfs_tool_lsuuid() {
   std::map<std::string, std::string>::iterator it;
   std::map<std::string, std::string> zenFileSystems = ListZenFileSystems();
@@ -452,6 +480,8 @@ int main(int argc, char **argv) {
     return ROCKSDB_NAMESPACE::zenfs_tool_restore();
   } else if (subcmd == "dump") {
     return ROCKSDB_NAMESPACE::zenfs_tool_dump();
+  } else if (subcmd == "stat") {
+    return ROCKSDB_NAMESPACE::zenfs_tool_stat();
   } else {
     fprintf(stderr, "Subcommand not recognized: %s\n", subcmd.c_str());
     return 1;

--- a/zenfs.mk
+++ b/zenfs.mk
@@ -1,3 +1,3 @@
 zenfs_SOURCES = fs/fs_zenfs.cc fs/zbd_zenfs.cc fs/io_zenfs.cc
-zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h
+zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/zbd_stat.h
 zenfs_LDFLAGS = -lzbd -u zenfs_filesystem_reg


### PR DESCRIPTION
This PR adds statistics API for ZenFS. Users can get statistics information from `zenFS->GetStat()`. It is also possible to print statistics in human-readable format with ZenFS cli tool `./zenfs stat --zbd=nvme3n2`.

Example output from the cli tool:

```
Zone total=1129316352 write_position=67701309440 start_position=66571993088
  [297] test_db/000296.sst 135135823
  [314] test_db/000313.sst 135136461
Zone total=1129316352 write_position=69848793088 start_position=68719476736
  [166] test_db/000165.sst 135140690
Zone total=1129316352 write_position=71996276736 start_position=70866960384
  [319] test_db/000318.sst 135136421
Zone total=1129316352 write_position=74143760384 start_position=73014444032
  [167] test_db/000166.sst 135140661
Zone total=1129316352 write_position=76291244032 start_position=75161927680
  [309] test_db/000308.sst 135140458
Zone total=1129316352 write_position=78438727680 start_position=77309411328
  [1066] test_db/001065.sst 135131464
```

Signed-off-by: Alex Chi <iskyzh@gmail.com>