### PR TITLE
fs: add fast path for WAL

### DIFF
--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -54,6 +54,7 @@ class ZoneFile {
   time_t m_time_;
   
   std::shared_ptr<Logger> logger_;
+  bool is_wal_;
 
  public:
   explicit ZoneFile(ZonedBlockDevice* zbd, std::string filename,

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -626,7 +626,7 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
   /* Make sure we are below the zone open limit */
   {
     std::unique_lock<std::mutex> lk(zone_resources_mtx_);
-    zone_resources_.wait(lk, [this, wal_fast_path] {
+    zone_resources_.wait(lk, [this] {
       if (open_io_zones_.load() < max_nr_open_io_zones_) return true;
       return false;
     });

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -110,7 +110,7 @@ class ZonedBlockDevice {
 
   Zone *GetIOZone(uint64_t offset);
 
-  Zone *AllocateZone(Env::WriteLifeTimeHint lifetime);
+  Zone *AllocateZone(Env::WriteLifeTimeHint lifetime, bool wal_fast_path);
   Zone *AllocateMetaZone();
 
   uint64_t GetFreeSpace();


### PR DESCRIPTION
If current file is WAL, we do not go through the reset and finish procedure.

There still could be lock contention issues, but the P99 latency will significantly reduce for WAL write. That is because zone allocation won't be called very frequently. So lock contention on `io_zones_mtx` won't be high.

After all, this is a quick and temporary fix for the spiking latency issue. We should investigate the locking scheme and try move locks out of critical path in later PRs.

Signed-off-by: Alex Chi <iskyzh@gmail.com>