### PR TITLE
*: limit reset to reduce latency

### DIFF
--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -625,7 +625,6 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
   unsigned int best_diff = LIFETIME_DIFF_NOT_GOOD;
   int new_zone = 0;
   Status s;
-  int reset_zone_cnt = 0;
 
   LatencyHistGuard guard(&io_alloc_latency_reporter_);
   io_alloc_qps_reporter_.AddCount(1);
@@ -657,13 +656,10 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
     // bounded latency: we reset at most 3 zones
     
     if (!z->IsUsed()) {
-      if (reset_zone_cnt < 3) {
-        if (!z->IsFull()) active_io_zones_--;
-        s = z->Reset();
-        reset_zone_cnt++;
-        if (!s.ok()) {
-          Warn(logger_, "Failed resetting zone !");
-        }
+      if (!z->IsFull()) active_io_zones_--;
+      s = z->Reset();
+      if (!s.ok()) {
+        Warn(logger_, "Failed resetting zone !");
       }
       continue;
     }

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -716,8 +716,6 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
 
   LogZoneStatsInternal();
   io_zones_mtx.unlock();
-  zone_resources_.notify_one();
-  zone_resources_fast_.notify_one();
 
   return allocated_zone;
 }

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -90,6 +90,7 @@ class ZonedBlockDevice {
   std::atomic<long> active_io_zones_;
   std::atomic<long> open_io_zones_;
   std::condition_variable zone_resources_;
+  std::condition_variable zone_resources_fast_;
   std::mutex zone_resources_mtx_; /* Protects active/open io zones */
 
   uint32_t max_nr_active_io_zones_;
@@ -122,6 +123,7 @@ class ZonedBlockDevice {
 
   void ResetUnusedIOZones();
   void LogZoneStats();
+  void LogZoneStatsInternal();
   void LogZoneUsage();
 
   int GetReadFD() { return read_f_; }
@@ -173,6 +175,7 @@ class ZonedBlockDevice {
   LatencyReporter sync_latency_reporter_;
   LatencyReporter meta_alloc_latency_reporter_;
   LatencyReporter io_alloc_latency_reporter_;
+  LatencyReporter io_alloc_actual_latency_reporter_;
   LatencyReporter roll_latency_reporter_;
 
   using QPSReporter = CountReporterHandle &;

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -90,7 +90,6 @@ class ZonedBlockDevice {
   std::atomic<long> active_io_zones_;
   std::atomic<long> open_io_zones_;
   std::condition_variable zone_resources_;
-  std::condition_variable zone_resources_fast_;
   std::mutex zone_resources_mtx_; /* Protects active/open io zones */
 
   uint32_t max_nr_active_io_zones_;
@@ -189,6 +188,10 @@ class ZonedBlockDevice {
   using ThroughputReporter = CountReporterHandle &;
   ThroughputReporter write_throughput_reporter_;
   ThroughputReporter roll_throughput_reporter_;
+
+  using DataReporter = HistReporterHandle &;
+  DataReporter active_zones_;
+  DataReporter open_zones_;
 
  private:
   std::string ErrorToString(int err);


### PR DESCRIPTION
This this PR, we switched the order of waiting conditional variable and io mutex, therefore allowing WAL to have higher priority over ordinary files. At the same time, we added a new metrics for recording actual resetting work happening inside the zone allocation. Therefore, we could see how much time is taken to wait lock and do allocation separately. Specifically, if total time is far larger than actual allocation time, there are too many files being opened and they are all waiting on a lock.

Signed-off-by: Alex Chi <iskyzh@gmail.com>