### PR TITLE
*: prioritize WAL allocation

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -981,6 +981,8 @@ Status ZenFS::Mount(bool readonly) {
     Info(logger_, "  Done");
   }
 
+  zbd_->InitializeZoneState();
+
   LogFiles();
 
   return Status::OK();

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -214,11 +214,11 @@ ZoneFile::~ZoneFile() {
 
 void ZoneFile::CloseWR() {
   if (active_zone_) {
-    Info(logger_, "Closing %s\n", filename_.c_str());
+    Warn(logger_, "Closing %s\n", filename_.c_str());
     active_zone_->CloseWR();
     active_zone_ = NULL;
   } else {
-    Info(logger_, "Active zone = nullptr, %s\n", filename_.c_str());
+    Warn(logger_, "Active zone = nullptr, %s\n", filename_.c_str());
   }
   open_for_wr_ = false;
 }

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -42,6 +42,10 @@ struct zenfs_aio_ctx {
   int fd;
 };
 
+enum ZoneState {
+  ZONE_UNKNOWN, ZONE_EMPTY, ZONE_IN_USE, ZONE_IDLE, ZONE_FULL
+};
+
 class Zone {
   ZonedBlockDevice *zbd_;
 
@@ -55,6 +59,7 @@ class Zone {
   bool open_for_write_;
   Env::WriteLifeTimeHint lifetime_;
   std::atomic<long> used_capacity_;
+  ZoneState state_;
   struct zenfs_aio_ctx wr_ctx;
 
   IOStatus Reset();
@@ -171,6 +176,8 @@ class ZonedBlockDevice {
   void NotifyIOZoneClosed();
 
   std::vector<ZoneStat> GetStat();
+
+  void InitializeZoneState();
 
   std::shared_ptr<MetricsReporterFactory> metrics_reporter_factory_;
   std::string bytedance_tags_;


### PR DESCRIPTION
This PR introduces a new scheme for WAL priority.

Only one thread could enter the critical section protected by `zone_resources_mtx_`, and the conditional variable `zone_resources_` have different condition for WAL and general files.


Signed-off-by: Alex Chi <iskyzh@gmail.com>