### PR TITLE
[WIP] Fix ZoneAllocation latency spike for WAL files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,90 @@
-BasedOnStyle: Google
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+apt-get install clang-format -y
+
+git diff --name-only | egrep '.*\.(h|cc|cpp|inl)' | xargs -r clang-format -style=file -i

--- a/format.sh
+++ b/format.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-apt-get install clang-format -y
-
-git diff --name-only | egrep '.*\.(h|cc|cpp|inl)' | xargs -r clang-format -style=file -i
+git diff --name-only | egrep '.*\.(h|cc|cpp|inl)' | xargs -r clang-format -i

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -348,7 +348,7 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size, bool async)
   IOStatus s;
 
   if (active_zone_ == NULL) {
-    active_zone_ = zbd_->AllocateZone(lifetime_, is_wal_);
+    active_zone_ = zbd_->AllocateZone(lifetime_, is_wal_, filename_);
     if (!active_zone_) {
       Warn(logger_, "Zone allocation failure upon append starting, filename=%s, lifetime=%d\n", filename_.c_str(), lifetime_);
       return IOStatus::NoSpace("Zone allocation failure\n");
@@ -362,7 +362,7 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size, bool async)
       PushExtent();
 
       active_zone_->CloseWR();
-      active_zone_ = zbd_->AllocateZone(lifetime_, is_wal_);
+      active_zone_ = zbd_->AllocateZone(lifetime_, is_wal_, filename_);
       if (!active_zone_) {
         Warn(logger_, "Zone allocation failure when appending, filename=%s, left=%d\n", filename_.c_str(), left);
         return IOStatus::NoSpace("Zone allocation failure\n");

--- a/fs/utils.h
+++ b/fs/utils.h
@@ -1,3 +1,8 @@
+// This header file is used for debugging, do not use the functions here unless
+// you understand what you are doing.
+//
+// guokuankuan@bytedance.com
+//
 #pragma once
 #include <chrono>
 #include <cstdio>
@@ -6,31 +11,62 @@
 #include <sstream>
 
 #ifdef ZENFS_DEBUG
-thread_local std::map<std::string, uint64_t> TimeTrace;
+
+// zone_id: filename, create_time
+static std::map<uint64_t, std::vector<std::pair<std::string, std::string>>>
+    opened_files;
+// filenames
+static std::set<std::string> opening_files;
+
+// Avoid std::cerr print interleave cross multiple concurrent threads.
+class LineWriter {
+ private:
+  std::ostringstream st;
+
+ public:
+  template <typename T>
+  LineWriter& operator<<(T const& t) {
+    st << t;
+    return *this;
+  }
+  ~LineWriter() {
+    std::string s = st.str();
+    std::cerr << s;
+  }
+};
+
+// Print all opened/opening files, opening files means these files are waiting
+// for zone allocation mutex.
+inline void PrintZoneFiles() {
+  LineWriter() << std::this_thread::get_id() << " Opening Files:\n";
+  {
+    LineWriter w;
+    w << "\t";
+    for (const auto& fname : opening_files) {
+      w << fname << ", ";
+    }
+    w << "\n";
+  }
+
+  LineWriter() << std::this_thread::get_id() << " Opened Files:\n";
+  {
+    LineWriter w;
+    for (const auto& mp : opened_files) {
+      w << "\t" << mp.first << " : ";
+      for (const auto& pair : mp.second) {
+        w << " {" << pair.first << ", " << pair.second << "}, ";
+      }
+      w << "\n";
+    }
+    w << "\n";
+  }
+}
 
 inline uint64_t GetCurrentTimeNanos() {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
              std::chrono::system_clock::now().time_since_epoch())
       .count();
 }
-
-class AtomicWriter {
- private:
-  std::ostringstream st;
-
- public:
-  template <typename T>
-  AtomicWriter& operator<<(T const& t) {
-    st << t;
-    return *this;
-  }
-  ~AtomicWriter() {
-    std::string s = st.str();
-    std::cerr << s;
-    // fprintf(stderr,"%s", s.c_str());
-    // write(2,s.c_str(),s.size());
-  }
-};
 
 inline uint64_t TimeDiff(
     const std::chrono::time_point<std::chrono::system_clock> before,
@@ -39,6 +75,7 @@ inline uint64_t TimeDiff(
       .count();
 }
 
+// Get string represent of current time, e.g.: 22:30:11
 inline const std::string CurrentTime() {
   time_t now = time(0);
   struct tm tstruct;
@@ -53,6 +90,9 @@ inline std::string GetDateString() {
   std::time_t now_time = std::chrono::system_clock::to_time_t(now);
   return std::ctime(&now_time);
 }
+
+// For quick time trace debugging
+thread_local std::map<std::string, uint64_t> TimeTrace;
 
 #define TIME_TRACE_START(tag) TimeTrace[tag] = GetCurrentTimeNanos();
 

--- a/fs/utils.h
+++ b/fs/utils.h
@@ -9,55 +9,57 @@
 thread_local std::map<std::string, uint64_t> TimeTrace;
 
 inline uint64_t GetCurrentTimeNanos() {
-  return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::system_clock::now().time_since_epoch())
+      .count();
 }
 
-
 class AtomicWriter {
-private:
-    std::ostringstream st;
+ private:
+  std::ostringstream st;
 
  public:
-    template <typename T> 
-    AtomicWriter& operator<<(T const& t) {
-       st << t;
-       return *this;
-    }
-    ~AtomicWriter() {
-       std::string s = st.str();
-       std::cerr << s;
-       //fprintf(stderr,"%s", s.c_str());
-       // write(2,s.c_str(),s.size());
-    }
- };
+  template <typename T>
+  AtomicWriter& operator<<(T const& t) {
+    st << t;
+    return *this;
+  }
+  ~AtomicWriter() {
+    std::string s = st.str();
+    std::cerr << s;
+    // fprintf(stderr,"%s", s.c_str());
+    // write(2,s.c_str(),s.size());
+  }
+};
 
-inline uint64_t TimeDiff(const std::chrono::time_point<std::chrono::system_clock> before,
-		         const std::chrono::time_point<std::chrono::system_clock> after) {
-	  return std::chrono::duration_cast<std::chrono::microseconds>(after - before).count();
+inline uint64_t TimeDiff(
+    const std::chrono::time_point<std::chrono::system_clock> before,
+    const std::chrono::time_point<std::chrono::system_clock> after) {
+  return std::chrono::duration_cast<std::chrono::microseconds>(after - before)
+      .count();
 }
 
 inline const std::string CurrentTime() {
-	  time_t now = time(0);
-	    struct tm tstruct;
-	      char buf[80];
-	        tstruct = *localtime(&now);
-		  strftime(buf, sizeof(buf), "%H:%M:%S", &tstruct);
-		    return buf;
+  time_t now = time(0);
+  struct tm tstruct;
+  char buf[80];
+  tstruct = *localtime(&now);
+  strftime(buf, sizeof(buf), "%H:%M:%S", &tstruct);
+  return buf;
 }
 
 inline std::string GetDateString() {
-	  auto now = std::chrono::system_clock::now();
-	    std::time_t now_time = std::chrono::system_clock::to_time_t(now);
-	      return std::ctime(&now_time);
+  auto now = std::chrono::system_clock::now();
+  std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+  return std::ctime(&now_time);
 }
 
-#define TIME_TRACE_START(tag) \
-  TimeTrace[tag] = GetCurrentTimeNanos();
+#define TIME_TRACE_START(tag) TimeTrace[tag] = GetCurrentTimeNanos();
 
 #define TIME_TRACE_END(tag) \
   TimeTrace[tag] = GetCurrentTimeNanos() - TimeTrace[tag];
 
-#define PRINT_TIME_TRACE()                               \
+#define PRINT_TIME_TRACE()                                     \
   for (const auto& item : TimeTrace) {                         \
     printf("\t%s : %ld ns\n", item.first.data(), item.second); \
   }                                                            \
@@ -70,4 +72,3 @@ inline std::string GetDateString() {
 #define TIME_TRACE_END(tag)
 #define PRINT_TIME_TRACE()
 #endif
-

--- a/fs/utils.h
+++ b/fs/utils.h
@@ -1,0 +1,73 @@
+#pragma once
+#include <chrono>
+#include <cstdio>
+#include <ctime>
+#include <iostream>
+#include <sstream>
+
+#ifdef ZENFS_DEBUG
+thread_local std::map<std::string, uint64_t> TimeTrace;
+
+inline uint64_t GetCurrentTimeNanos() {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+}
+
+
+class AtomicWriter {
+private:
+    std::ostringstream st;
+
+ public:
+    template <typename T> 
+    AtomicWriter& operator<<(T const& t) {
+       st << t;
+       return *this;
+    }
+    ~AtomicWriter() {
+       std::string s = st.str();
+       std::cerr << s;
+       //fprintf(stderr,"%s", s.c_str());
+       // write(2,s.c_str(),s.size());
+    }
+ };
+
+inline uint64_t TimeDiff(const std::chrono::time_point<std::chrono::system_clock> before,
+		         const std::chrono::time_point<std::chrono::system_clock> after) {
+	  return std::chrono::duration_cast<std::chrono::microseconds>(after - before).count();
+}
+
+inline const std::string CurrentTime() {
+	  time_t now = time(0);
+	    struct tm tstruct;
+	      char buf[80];
+	        tstruct = *localtime(&now);
+		  strftime(buf, sizeof(buf), "%H:%M:%S", &tstruct);
+		    return buf;
+}
+
+inline std::string GetDateString() {
+	  auto now = std::chrono::system_clock::now();
+	    std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+	      return std::ctime(&now_time);
+}
+
+#define TIME_TRACE_START(tag) \
+  TimeTrace[tag] = GetCurrentTimeNanos();
+
+#define TIME_TRACE_END(tag) \
+  TimeTrace[tag] = GetCurrentTimeNanos() - TimeTrace[tag];
+
+#define PRINT_TIME_TRACE()                               \
+  for (const auto& item : TimeTrace) {                         \
+    printf("\t%s : %ld ns\n", item.first.data(), item.second); \
+  }                                                            \
+  printf("\n");
+
+// Limit for capture long latency (millisecond level)
+#define LONG_LATENCY_THRESHOLD 50 * 1000 * 1000
+#else
+#define TIME_TRACE_START(tag)
+#define TIME_TRACE_END(tag)
+#define PRINT_TIME_TRACE()
+#endif
+

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -657,7 +657,7 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
   auto t1 = std::chrono::system_clock::now();
 
   /* Reset any unused zones and finish used zones under capacity treshold*/
-  for (int i = 0; i < io_zones.size(); i++) {
+  for (int i = 0; !is_wal && i < io_zones.size(); i++) {
     // Unlock wal mutex and give wal thread a chance
     if (!is_wal && wal_zone_allocating_.load() > 0) {
       wal_zones_mtx.unlock();
@@ -688,7 +688,7 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
         Warn(logger_, "Failed resetting zone !");
       }
       // For wal file, we only reset once.
-      if (is_wal) break;
+      // if (is_wal) break;
 
       continue;
     }
@@ -704,7 +704,7 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
       active_io_zones_--;
     }
 
-    // Find a vitim with the smallest capacity.
+    // Find a victim with the smallest capacity.
     if (!z->IsFull()) {
       if (finish_victim == nullptr) {
         finish_victim = z;

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -85,7 +85,7 @@ void Zone::CloseWR() {
   open_for_write_ = false;
 
   // For debug, track all opened files
-  opened_files.erase(start_ >> 30);
+  // opened_files.erase(start_ >> 30);
   std::lock_guard<std::mutex> lock(zbd_->zone_resources_mtx_);
   if (Close().ok()) {
     zbd_->NotifyIOZoneClosed();
@@ -619,7 +619,7 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
   // than 1
   // WAL files alive (which may happen in RocksDB/TerarkDB)
   int reserved_zones = 2;
-  opening_files.emplace(fname);
+  // opening_files.emplace(fname);
 
   LatencyHistGuard guard(&io_alloc_latency_reporter_);
   io_alloc_qps_reporter_.AddCount(1);
@@ -789,9 +789,9 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
   // we don't acquire lock here since there's almost not possible to have
   // multiple threads manipulate the same file,
   // This is not thread safe, but is enough for quick debug
-  opening_files.erase(fname);
-  opened_files[allocated_zone->start_ >> 30].emplace_back(fname, CurrentTime());
-  PrintZoneFiles();
+  // opening_files.erase(fname);
+  // opened_files[allocated_zone->start_ >> 30].emplace_back(fname, CurrentTime());
+  // PrintZoneFiles();
 
   return allocated_zone;
 }

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -784,9 +784,8 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
   active_zones_reporter_.AddRecord(active_io_zones_);
 
   std::stringstream ss;
-  ss << CurrentTime() << " Tid = " << std::this_thread::get_id() << " is_wal = " << is_wal << " a/o zones "
-     << active_io_zones_.load() << "," << open_io_zones_.load() << " lock wait: " << TimeDiff(t0, t1)
-     << ", reset: " << TimeDiff(t1, t2) << ", other: " << TimeDiff(t2, t5)
+  ss << " is_wal = " << is_wal << " a/o zones " << active_io_zones_.load() << "," << open_io_zones_.load()
+     << " lock wait: " << TimeDiff(t0, t1) << ", reset: " << TimeDiff(t1, t2) << ", other: " << TimeDiff(t2, t5)
      << ", wal_alloc: " << wal_zone_allocating_.load() << "\n";
 
   Info(logger_, "%s", ss.str().c_str());

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -92,7 +92,6 @@ void Zone::CloseWR() {
   }
 
   if (capacity_ == 0) zbd_->NotifyIOZoneFull();
-
 }
 
 IOStatus Zone::Reset() {
@@ -149,7 +148,7 @@ IOStatus Zone::Close() {
     if (ret) return IOStatus::IOError("Zone close failed\n");
   }
 
-	open_for_write_ = false;
+  open_for_write_ = false;
 
   return IOStatus::OK();
 }
@@ -618,10 +617,9 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
   int new_zone = 0;
   Status s;
 
-  // We will always reserve a few zones for WAL files in case there are more
-  // than 1
-  // WAL files alive (which may happen in RocksDB/TerarkDB)
-  int reserved_zones = 2;
+  // We shall reserve one more free zone for WAL files.
+  // TODO(guokuankuan) Maybe we should also let L0 files use this zone?
+  int reserved_zones = 1;
   // opening_files.emplace(fname);
 
   LatencyHistGuard guard(&io_alloc_latency_reporter_);

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -785,7 +785,7 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
 
   LineWriter() << CurrentTime() << " Tid = " << std::this_thread::get_id() << " is_wal = " << is_wal
                << " active/open zones " << active_io_zones_.load() << "," << open_io_zones_.load()
-               << " lock wait: " << TimeDiff(t0, t1) << ", total time: " << TimeDiff(t1, t5)
+               << " lock wait: " << TimeDiff(t0, t1) << ", work time: " << TimeDiff(t1, t5)
                << ", wal_alloc: " << wal_zone_allocating_.load() << "\n";
 
   // For debug (guokuankuan)

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -117,9 +117,7 @@ class ZonedBlockDevice {
 
   Zone *GetIOZone(uint64_t offset);
 
-  Zone *AllocateZone(Env::WriteLifeTimeHint lifetime, bool is_wal,
-                     uint64_t timeout_ns);
-  Zone *AllocateZone(Env::WriteLifeTimeHint lifetime, bool is_wal);
+  Zone *AllocateZone(Env::WriteLifeTimeHint lifetime, bool is_wal, const std::string& fname);
   Zone *AllocateMetaZone();
 
   uint64_t GetFreeSpace();

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -117,7 +117,8 @@ class ZonedBlockDevice {
 
   Zone *GetIOZone(uint64_t offset);
 
-  Zone *AllocateZone(Env::WriteLifeTimeHint lifetime, bool is_wal, uint64_t timeout_ns);
+  Zone *AllocateZone(Env::WriteLifeTimeHint lifetime, bool is_wal,
+                     uint64_t timeout_ns);
   Zone *AllocateZone(Env::WriteLifeTimeHint lifetime, bool is_wal);
   Zone *AllocateMetaZone();
 

--- a/run_db_bench.sh
+++ b/run_db_bench.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# We can use this script to run basic db_bench tests.
+#
+
+HOME=$PWD
+DEVICE=nvme8n2
+
+#cd output && make -j40
+
+cd $HOME
+
+# Delete existing `aux_path`, which is used for temporary files (e.g. lock), ZenFS doesn't write 
+# actual user data into these files.
+#rm -rf /tmp/zenfs_$DEVICE
+
+# Format target device
+#./output/zenfs mkfs --zbd=$DEVICE --aux_path=/tmp/zenfs_$DEVICE --finish_threshold=5 --force
+
+./output/db_bench \
+  --zbd_path=$DEVICE \
+	--benchmarks=readrandom \
+	--use_existing_db=1 \
+	--statistics=0 \
+  --stats_per_interval=1 \
+  --stats_interval_seconds=60 \
+  --max_background_flushes=2 \
+	--max_background_compactions=8 \
+	--enable_lazy_compaction=0 \
+	--level0_file_num_compaction_trigger=4 \
+	--sync=1 \
+	--allow_concurrent_memtable_write=1 \
+	--bytes_per_sync=262144 \
+	--wal_bytes_per_sync=32768 \
+	--delayed_write_rate=419430400 \
+	--enable_write_thread_adaptive_yield=1 \
+	--num_levels=7 \
+	--key_size=36 \
+	--value_size=8192 \
+	--level_compaction_dynamic_level_bytes=true \
+	--mmap_read=false \
+	--compression_type=zstd \
+	--memtablerep=skip_list \
+	--use_terark_table=false \
+	--blob_size=1024 \
+	--blob_gc_ratio=0.0625 \
+	--write_buffer_size=268435456 \
+	--max_write_buffer_number=20 \
+	--target_file_size_base=268435456 \
+	--target_blob_file_size=268435456 \
+	--blob_file_defragment_size=33554432 \
+	--max_dependence_blob_overlap=128 \
+	--optimize_filters_for_hits=true \
+	--optimize_range_deletion=true \
+	--num=12000000 \
+	--db=test_db_1 \
+	--benchmark_write_rate_limit=300000000 \
+	--threads=16 \
+	--batch_size=100 \
+	--prepare_log_writer_num=0 \
+	--num_column_families=5 \
+	--zenfs_gc_ratio=0.3


### PR DESCRIPTION
Problem:
- When WAL writes want to allocate a new zone, it may be blocked by background writes (e.g. SST) which is not expected

Solution:
- Allow SST data writes can give up running if there is a WAL write coming by changing the lock details of  `AllocateZone`.