### PR TITLE
metrics: split wal and sst matrics in zone alloc panel

### DIFF
--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -176,8 +176,10 @@ class ZonedBlockDevice {
   LatencyReporter read_latency_reporter_;
   LatencyReporter sync_latency_reporter_;
   LatencyReporter meta_alloc_latency_reporter_;
-  LatencyReporter io_alloc_latency_reporter_;
-  LatencyReporter io_alloc_actual_latency_reporter_;
+  LatencyReporter io_alloc_wal_latency_reporter_;
+  LatencyReporter io_alloc_wal_actual_latency_reporter_;
+  LatencyReporter io_alloc_non_wal_latency_reporter_;
+  LatencyReporter io_alloc_non_wal_actual_latency_reporter_;
   LatencyReporter roll_latency_reporter_;
 
   using QPSReporter = CountReporterHandle &;


### PR DESCRIPTION
This PR added a feature for matrics which can split the WAL and Other in the Zone allocation panel. 

Now, one can choose terarkdb.engine.stats.zenfs_io_alloc_wal_latency_max and terarkdb.engine.stats.zenfs_io_alloc_other_latency_max for different parameters. 

Test plan:
Attached screenshot for updated panel: https://bytedance.feishu.cn/docs/doccn0cPwjgC7JHHAwEo8CnrQRA. 

Note:
clang-format is not applied for this PR as the formatting will also changes other files/lines irrelevant to this PR. Formatting can be applied in a separate PR for easier review. 