### PR TITLE
Async metadata alloc

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -295,7 +295,8 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   LatencyHistGuard guard(&zbd_->roll_latency_reporter_);
   zbd_->roll_qps_reporter_.AddCount(1);
 
-  new_meta_zone = zbd_->AllocateMetaZone();
+  new_meta_zone = zbd_->AllocateMetaZoneLocked(metadata_reset_mtx_);
+
   if (!new_meta_zone) {
     assert(false);  // TMP
     Error(logger_, "Out of metadata zones, we should go to read only now.");
@@ -312,6 +313,7 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   if (old_meta_zone->GetCapacityLeft()) WriteEndRecord(meta_log_.get());
   if (old_meta_zone->GetCapacityLeft()) old_meta_zone->Finish();
 
+  auto old_meta_log = std::move(meta_log_);
   meta_log_.reset(new_meta_log);
 
   std::string super_string;
@@ -327,7 +329,18 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   s = WriteSnapshotLocked(meta_log_.get());
 
   /* We've rolled successfully, we can reset the old zone now */
-  if (s.ok()) old_meta_zone->Reset();
+  if (s.ok()) {
+    std::thread backgroundTask([old_meta_log = std::move(old_meta_log), this] {
+      auto meta_zone = old_meta_log->GetZone();
+      std::unique_lock<std::mutex> lk(metadata_reset_mtx_);
+      meta_zone->Reset();
+
+      // metazone reset finished, notify the RollMetaZoneLocked() if any
+      metadata_cv_.notify_one();
+    });
+
+    backgroundTask.detach();
+  }
 
   auto new_meta_zone_size =
       meta_log_->GetZone()->wp_ - meta_log_->GetZone()->start_;

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -295,7 +295,7 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   LatencyHistGuard guard(&zbd_->roll_latency_reporter_);
   zbd_->roll_qps_reporter_.AddCount(1);
 
-  new_meta_zone = zbd_->AllocateMetaZoneLocked(metadata_reset_mtx_);
+  new_meta_zone = zbd_->AllocateMetaZone(metadata_reset_mtx_, metadata_reset_cv_);
 
   if (!new_meta_zone) {
     assert(false);  // TMP

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -127,6 +127,8 @@ class ZenFS : public FileSystemWrapper {
   std::unique_ptr<ZenMetaLog> meta_log_;
   std::mutex metadata_sync_mtx_;
   std::unique_ptr<Superblock> superblock_;
+  std::mutex metadata_reset_mtx_;
+  std::condition_variable metadata_cv_;
 
   std::shared_ptr<Logger> GetLogger() { return logger_; }
 

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -128,6 +128,7 @@ class ZenFS : public FileSystemWrapper {
   std::mutex metadata_sync_mtx_;
   std::unique_ptr<Superblock> superblock_;
   std::mutex metadata_reset_mtx_;
+  std::condition_variable metadata_reset_cv_;
   std::condition_variable metadata_cv_;
 
   std::shared_ptr<Logger> GetLogger() { return logger_; }

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -642,13 +642,17 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
   // We reserve one more free zone for WAL files in case RocksDB delay close WAL files.
   int reserved_zones = 1;
 
-  LatencyHistGuard guard_total;
-  LatencyHistGuard guard_actual;
-  
   auto *reporter_total = is_wal ? &io_alloc_wal_latency_reporter_
           : &io_alloc_non_wal_latency_reporter_;
 
   guard_total.count_now(reporter_total);
+  LatencyHistGuard guard_wal;
+  LatencyHistGuard guard_non_wal;
+  LatencyHistGuard guard_wal_actual;
+  LatencyHistGuard guard_non_wal_actual;
+
+  guard_non_wal.count_now(&io_alloc_non_wal_latency_reporter_);
+  guard_wal.count_now(&io_alloc_wal_latency_reporter_);
 
   io_alloc_qps_reporter_.AddCount(1);
 

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -651,9 +651,6 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
   LatencyHistGuard guard_wal_actual;
   LatencyHistGuard guard_non_wal_actual;
 
-  guard_non_wal.count_now(&io_alloc_non_wal_latency_reporter_);
-  guard_wal.count_now(&io_alloc_wal_latency_reporter_);
-
   io_alloc_qps_reporter_.AddCount(1);
 
   auto t0 = std::chrono::system_clock::now();

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -125,6 +125,7 @@ class ZonedBlockDevice {
   Zone *GetIOZone(uint64_t offset);
 
   Zone *AllocateZone(Env::WriteLifeTimeHint lifetime, bool is_wal);
+  Zone *AllocateMetaZoneLocked(std::mutex& metadata_reset_mtx);
   Zone *AllocateMetaZone();
 
   uint64_t GetFreeSpace();

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -125,8 +125,7 @@ class ZonedBlockDevice {
   Zone *GetIOZone(uint64_t offset);
 
   Zone *AllocateZone(Env::WriteLifeTimeHint lifetime, bool is_wal);
-  Zone *AllocateMetaZoneLocked(std::mutex& metadata_reset_mtx);
-  Zone *AllocateMetaZone();
+  Zone *AllocateMetaZone(std::mutex& metadata_reset_mtx, std::condition_variable& cv);
 
   uint64_t GetFreeSpace();
   uint64_t GetUsedSpace();


### PR DESCRIPTION
This PR adds async support for metadata reset. I would like to get some initial feedback and then make official PR to dev branch (also deleting the debug related changes).

- detach the metazone Reset() asynchronously 
- when RollMetaZoneLocked(), we will make two attempts to get a resetted zone to ensure we find a reset zone. First time acquire a lock, and the second time yield and re-acquire the lock.

Note: 
- this PR will cause disk wipeout command failed. Inspecting in progress.
- the commit history is a bit off due to my rebase