### PR TITLE
bugFix: backgroundWorker destructor

### DIFF
--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -289,6 +289,8 @@ BackgroundWorker::~BackgroundWorker() {
   for (auto& job : jobs_) {
     job();
   }
+  Terminate();
+  worker_.join();
 }
 
 void BackgroundWorker::Wait() {


### PR DESCRIPTION
- update BackgroundWorker's state to terminated in its destructor to avoid deadlock
- terminate main worker thread in the destructor 

With previous version, we will meet core dump. Here is error log when I tried to create a BackgroundWorker object in a separate test:

```
Thread 1 "backgroundWorke" received signal SIGABRT, Aborted.
0x00007ffff7885ce1 in raise () from /lib/x86_64-linux-gnu/libc.so.6
(gdb) bt
#0  0x00007ffff7885ce1 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007ffff786f537 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007ffff7c077ec in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00007ffff7c12966 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007ffff7c129d1 in std::terminate() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x000055555562c291 in std::thread::~thread (this=0x7fffffffe898, __in_chrg=<optimized out>) at /usr/include/c++/10/thread:157
#6  0x0000555555627cf7 in terarkdb::BackgroundWorker::~BackgroundWorker (this=0x7fffffffe890, __in_chrg=<optimized out>)
    at /data04/weile/internal/terarkdb-byted/third-party/zenfs/fs/zbd_zenfs.cc:287
#7  0x00005555555d63b0 in terarkdb::test ()
    at /data04/weile/internal/terarkdb-byted/third-party/zenfs/test/backgroundWorker_test.cc:19
#8  0x00005555555d64d7 in main (argc=1, argv=0x7fffffffeac8)
    at /data04/weile/internal/terarkdb-byted/third-party/zenfs/test/backgroundWorker_test.cc:31
```

With this change, my test works.