### PR TITLE
modify background worker logic and add unit tests

### DIFF
--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -92,8 +92,8 @@ class Zone {
 class BackgroundJob {
  public:
   BackgroundJob(std::function<int(void *)> fn, void *arg)
-      : fn_(fn), arg_(arg) {}
-  std::function<int(void *)> fn_;
+       : fn_(fn), arg_(arg) {}
+   std::function<int(void *)> fn_;
   void *arg_;
   virtual void operator()() { fn_(arg_); }
   virtual ~BackgroundJob() {}
@@ -102,13 +102,13 @@ class BackgroundJob {
 class ErrorHandlingBGJob : public BackgroundJob {
  public:
   ErrorHandlingBGJob(std::function<int(void *)> fn, void *arg,
-                     std::function<void(int)> handler)
-      : BackgroundJob(fn, arg), handler_(handler) {}
-  ErrorHandlingBGJob(std::function<int(void *)> fn, void *arg,
-                     std::function<void(int)> &&handler)
-      : BackgroundJob(fn, arg), handler_(handler) {}
-  std::function<void(int)> handler_;
-  virtual void operator()() override { handler_(fn_(arg_)); }
+                      std::function<void(int)> handler)
+       : BackgroundJob(fn, arg), handler_(handler) {}
+   ErrorHandlingBGJob(std::function<int(void *)> fn, void *arg,
+                      std::function<void(int)> &&handler)
+       : BackgroundJob(fn, arg), handler_(handler) {}
+   std::function<void(int)> handler_;
+   virtual void operator()() override { handler_(fn_(arg_)); }
 };
 
 class BackgroundWorker {
@@ -117,6 +117,7 @@ class BackgroundWorker {
   std::list<BackgroundJob> jobs_;
   std::unique_ptr<BackgroundJob> job_now_;
   std::mutex job_mtx_;
+  std::condition_variable job_cv_;
 
  public:
   BackgroundWorker(bool run_at_beginning = true);

--- a/test/backgroundWorker_test.cc
+++ b/test/backgroundWorker_test.cc
@@ -27,13 +27,36 @@ int deep_thought(void* arg) {
   return 42;
 }
 
+// Assume this arg contains zone number that you wanna operate with, which is a int
+int arg_deep_thought(void* arg) {
+  int elapsed_time = rand() % 1000;
+  std::this_thread::sleep_for(std::chrono::microseconds(elapsed_time));
+  // Get the correct type manually
+  int zone_number = *(int*) arg;
+  // Do the job with the arg brings in.
+  std::cout << "operating zone:" << zone_number << std::endl;
+  // return value shows is this operation successfully done or not,
+  // most commonly, 0 stands for success, other stands for failed,
+  // For jobs that could failed, using the errorhandlingbgjob which 
+  // will get this return value and process error handling.
+  return 0;
+}
+  
+std:vector<int> zone_numbers;
+  
 int test() {
   BackgroundWorker bg_worker;
   int num_jobs = 1000000;
-
   for (int i = 0; i < num_jobs; i++) {
-    bg_worker.SubmitJob(&ROCKSDB_NAMESPACE::deep_thought, &question);
+    // Assume job for each zone.
+    zone_numbers.emplace_back(i);
+    // Submit the job with zone_number[i] where hold the zone number.
+    bg_worker.SubmitJob(&ROCKSDB_NAMESPACE::arg_deep_thought, &zone_numbers[i]);
   }
+  
+//   for (int i = 0; i < num_jobs; i++) {
+//     bg_worker.SubmitJob(&ROCKSDB_NAMESPACE::deep_thought, &question);
+//   }
   return 0;
 }
 }  // namespace ROCKSDB_NAMESPACE

--- a/test/backgroundWorker_test.cc
+++ b/test/backgroundWorker_test.cc
@@ -7,8 +7,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <atomic>
 #include <chrono>
 #include <iostream>
+#include <numeric>
 #include <stdlib.h>
 #include <string>
 #include <thread>
@@ -19,44 +21,50 @@ using GFLAGS_NAMESPACE::SetUsageMessage;
 
 namespace ROCKSDB_NAMESPACE {
 
-std::string question = "Question of Life, the Universe, and Everything";
+const int num_jobs = 100000;
+std::vector<int> zone_numbers(num_jobs);
+std::atomic<int> actual_zone_number_sum(0);
 
-int deep_thought(void* arg) {
-  int elapsed_time = rand() % 1000;
-  std::this_thread::sleep_for(std::chrono::microseconds(elapsed_time));
-  return 42;
+void reset_zone_numbers_vec_and_sum() {
+  actual_zone_number_sum = 0;
+
+  for (int i = 0; i < zone_numbers.size(); i++) {
+    zone_numbers[i] = i;
+  }
 }
 
 // Assume this arg contains zone number that you wanna operate with, which is a int
-int arg_deep_thought(void* arg) {
+int sum_zone_number(void* arg) {
   int elapsed_time = rand() % 1000;
   std::this_thread::sleep_for(std::chrono::microseconds(elapsed_time));
   // Get the correct type manually
   int zone_number = *(int*) arg;
   // Do the job with the arg brings in.
-  std::cout << "operating zone:" << zone_number << std::endl;
+  actual_zone_number_sum += zone_number;
+
   // return value shows is this operation successfully done or not,
   // most commonly, 0 stands for success, other stands for failed,
   // For jobs that could failed, using the errorhandlingbgjob which 
   // will get this return value and process error handling.
   return 0;
 }
-  
-std:vector<int> zone_numbers;
-  
-int test() {
-  BackgroundWorker bg_worker;
-  int num_jobs = 1000000;
-  for (int i = 0; i < num_jobs; i++) {
-    // Assume job for each zone.
-    zone_numbers.emplace_back(i);
-    // Submit the job with zone_number[i] where hold the zone number.
-    bg_worker.SubmitJob(&ROCKSDB_NAMESPACE::arg_deep_thought, &zone_numbers[i]);
+
+int test_sum_in_background_worker() {
+  reset_zone_numbers_vec_and_sum();
+
+  {
+    BackgroundWorker bg_worker;
+    for (int i = 0; i < zone_numbers.size(); i++) {
+      // Submit the job with zone_number[i] where hold the zone number.
+      bg_worker.SubmitJob(&ROCKSDB_NAMESPACE::sum_zone_number, &zone_numbers[i]);
+    }
   }
-  
-//   for (int i = 0; i < num_jobs; i++) {
-//     bg_worker.SubmitJob(&ROCKSDB_NAMESPACE::deep_thought, &question);
-//   }
+
+  const int expected_zone_number_sum =
+      std::accumulate(zone_numbers.cbegin(), zone_numbers.cend(), 0);
+
+  assert(actual_zone_number_sum == expected_zone_number_sum);
+
   return 0;
 }
 }  // namespace ROCKSDB_NAMESPACE
@@ -68,5 +76,5 @@ int main(int argc, char **argv) {
 
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
-  return ROCKSDB_NAMESPACE::test();
+  return ROCKSDB_NAMESPACE::test_sum_in_background_worker();
 }

--- a/test/backgroundWorker_test.cc
+++ b/test/backgroundWorker_test.cc
@@ -1,0 +1,49 @@
+#include <dirent.h>
+#include <fcntl.h>
+#include <gflags/gflags.h>
+#include <rocksdb/file_system.h>
+#include <rocksdb/plugin/zenfs/fs/fs_zenfs.h>
+#include <rocksdb/plugin/zenfs/fs/zbd_zenfs.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <chrono>
+#include <iostream>
+#include <stdlib.h>
+#include <string>
+#include <thread>
+
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::RegisterFlagValidator;
+using GFLAGS_NAMESPACE::SetUsageMessage;
+
+namespace ROCKSDB_NAMESPACE {
+
+std::string question = "Question of Life, the Universe, and Everything";
+
+int deep_thought(void* arg) {
+  int elapsed_time = rand() % 1000;
+  std::this_thread::sleep_for(std::chrono::microseconds(elapsed_time));
+  return 42;
+}
+
+int test() {
+  BackgroundWorker bg_worker;
+  int num_jobs = 1000000;
+
+  for (int i = 0; i < num_jobs; i++) {
+    bg_worker.SubmitJob(&ROCKSDB_NAMESPACE::deep_thought, &question);
+  }
+  return 0;
+}
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char **argv) {
+  gflags::SetUsageMessage(std::string("\nUSAGE:\n") + std::string(argv[0]) +
+                            +" <command> [OPTIONS]...\nCommands: mkfs, list, "
+                             "ls-uuid, df, backup, restore");
+
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  return ROCKSDB_NAMESPACE::test();
+}


### PR DESCRIPTION
- added condition variable to coordinate background job submission, process, and ending
  - update BackgroundWorker's state to terminated in its destructor to avoid deadlock
  - terminate main worker thread in the destructor 
  - reset job_now_ pointer to the front of job queue instead of direct assignment which led to segfault  

- added unit test which simulates I million tasks submission

With previous version, we will meet core dump. Here is error log when I tried to create a BackgroundWorker object in a separate test:

```
Thread 1 "backgroundWorke" received signal SIGABRT, Aborted.
0x00007ffff7885ce1 in raise () from /lib/x86_64-linux-gnu/libc.so.6
(gdb) bt
#0  0x00007ffff7885ce1 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007ffff786f537 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007ffff7c077ec in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00007ffff7c12966 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007ffff7c129d1 in std::terminate() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x000055555562c291 in std::thread::~thread (this=0x7fffffffe898, __in_chrg=<optimized out>) at /usr/include/c++/10/thread:157
#6  0x0000555555627cf7 in terarkdb::BackgroundWorker::~BackgroundWorker (this=0x7fffffffe890, __in_chrg=<optimized out>)
    at /data04/weile/internal/terarkdb-byted/third-party/zenfs/fs/zbd_zenfs.cc:287
#7  0x00005555555d63b0 in terarkdb::test ()
    at /data04/weile/internal/terarkdb-byted/third-party/zenfs/test/backgroundWorker_test.cc:19
#8  0x00005555555d64d7 in main (argc=1, argv=0x7fffffffeac8)
    at /data04/weile/internal/terarkdb-byted/third-party/zenfs/test/backgroundWorker_test.cc:31
```

With this change, my test works.