### PR TITLE
fs: fix zenfs.mkfs and plugin path problems

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -295,7 +295,7 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   LatencyHistGuard guard(&zbd_->roll_latency_reporter_);
   zbd_->roll_qps_reporter_.AddCount(1);
 
-  new_meta_zone = zbd_->AllocateMetaZone(metadata_reset_mtx_, metadata_reset_cv_);
+  new_meta_zone = zbd_->AllocateMetaZone();
 
   if (!new_meta_zone) {
     assert(false);  // TMP
@@ -305,7 +305,6 @@ IOStatus ZenFS::RollMetaZoneLocked() {
 
   Info(logger_, "Rolling to metazone %d\n", (int)new_meta_zone->GetZoneNr());
   new_meta_log = new ZenMetaLog(zbd_, new_meta_zone);
-
   old_meta_zone = meta_log_->GetZone();
   old_meta_zone->open_for_write_ = false;
 
@@ -313,7 +312,6 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   if (old_meta_zone->GetCapacityLeft()) WriteEndRecord(meta_log_.get());
   if (old_meta_zone->GetCapacityLeft()) old_meta_zone->Finish();
 
-  auto old_meta_log = std::move(meta_log_);
   meta_log_.reset(new_meta_log);
 
   std::string super_string;

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -330,16 +330,12 @@ IOStatus ZenFS::RollMetaZoneLocked() {
 
   /* We've rolled successfully, we can reset the old zone now */
   if (s.ok()) {
-    std::thread backgroundTask([old_meta_log = std::move(old_meta_log), this] {
-      auto meta_zone = old_meta_log->GetZone();
-      std::unique_lock<std::mutex> lk(metadata_reset_mtx_);
-      meta_zone->Reset();
-
-      // metazone reset finished, notify the RollMetaZoneLocked() if any
-      metadata_cv_.notify_one();
+    auto t = std::thread([&, old_meta_zone]() {
+      std::unique_lock<std::mutex> lk(zbd_->metazone_reset_mtx_);
+      old_meta_zone->Reset();
+      zbd_->metazone_reset_cv_.notify_one();
     });
-
-    backgroundTask.detach();
+    t.detach();
   }
 
   auto new_meta_zone_size =
@@ -1063,8 +1059,8 @@ Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold,
 
   log.reset(new ZenMetaLog(zbd_, meta_zone));
 
-  Superblock* super = new Superblock(zbd_, aux_fs_path,
-                          finish_threshold, max_open_limit, max_active_limit);
+  Superblock* super = new Superblock(zbd_, aux_fs_path, finish_threshold,
+                                     max_open_limit, max_active_limit);
   std::string super_string;
   super->EncodeTo(&super_string);
 
@@ -1159,7 +1155,7 @@ Status NewZenFS(
   }
   ZonedBlockDevice* zbd = new ZonedBlockDevice(
       bdevname, logger, bytedance_tags_, metrics_reporter_factory_);
-	IOStatus zbd_status = zbd->Open();
+  IOStatus zbd_status = zbd->Open();
   if (!zbd_status.ok()) {
     Error(logger, "Failed to open zoned block device: %s",
           zbd_status.ToString().c_str());

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -9,8 +9,8 @@
 #include "io_zenfs.h"
 #include "rocksdb/env.h"
 #include "rocksdb/file_system.h"
-#include "rocksdb/plugin/zenfs/fs/zbd_stat.h"
 #include "rocksdb/status.h"
+#include "zbd_stat.h"
 #include "zbd_zenfs.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -43,8 +43,8 @@ class Superblock {
   /* Create a superblock for a filesystem covering the entire zoned block device
    */
   Superblock(ZonedBlockDevice* zbd, std::string aux_fs_path,
-             uint32_t finish_threshold,
-             uint32_t max_open_limit, uint32_t max_active_limit) {
+             uint32_t finish_threshold, uint32_t max_open_limit,
+             uint32_t max_active_limit) {
     std::string uuid = Env::Default()->GenerateUniqueId();
     int uuid_len =
         std::min(uuid.length(),
@@ -64,7 +64,7 @@ class Superblock {
     } else {
       max_open_limit_ = max_open_limit;
     }
-    
+
     if (max_active_limit == 0) {
       max_active_limit_ = zbd->GetMaxActiveZones();
     } else {

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -127,9 +127,6 @@ class ZenFS : public FileSystemWrapper {
   std::unique_ptr<ZenMetaLog> meta_log_;
   std::mutex metadata_sync_mtx_;
   std::unique_ptr<Superblock> superblock_;
-  std::mutex metadata_reset_mtx_;
-  std::condition_variable metadata_reset_cv_;
-  std::condition_variable metadata_cv_;
 
   std::shared_ptr<Logger> GetLogger() { return logger_; }
 

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -676,20 +676,12 @@ Zone *ZonedBlockDevice::AllocateMetaZone() {
           Warn(logger_, "Failed resetting zone!");
           continue;
         }
-        return z;
       }
+      return z;
     }
-    return nullptr;
-  };
+  }
 
-  Zone* allocated_zone = nullptr;
-  std::unique_lock<std::mutex> lk(metadata_reset_mtx);
-  metadata_cv.wait(lk, [&allocated_zone, getResettedMetaZone]{
-    allocated_zone = getResettedMetaZone();
-    return allocated_zone != nullptr;
-  });
-
-  return allocated_zone;
+  return nullptr;
 }
 
 void ZonedBlockDevice::ResetUnusedIOZones() {

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -31,7 +31,7 @@
 #include "rocksdb/env.h"
 #include "rocksdb/io_status.h"
 #include "rocksdb/metrics_reporter.h"
-#include "rocksdb/plugin/zenfs/fs/zbd_stat.h"
+#include "zbd_stat.h"
 
 namespace ROCKSDB_NAMESPACE {
 

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -11,6 +11,7 @@
 
 #include <errno.h>
 #include <libaio.h>
+#include <libaio.h>
 #include <libzbd/zbd.h>
 #include <stdlib.h>
 #include <string.h>
@@ -170,6 +171,9 @@ class ZonedBlockDevice {
  public:
   std::mutex zone_resources_mtx_; /* Protects active/open io zones */
 
+  std::mutex metazone_reset_mtx_;
+  std::condition_variable metazone_reset_cv_;
+
  public:
   explicit ZonedBlockDevice(std::string bdevname,
                             std::shared_ptr<Logger> logger);
@@ -186,8 +190,7 @@ class ZonedBlockDevice {
   Zone *GetIOZone(uint64_t offset);
 
   Zone *AllocateZone(Env::WriteLifeTimeHint lifetime, bool is_wal);
-  Zone *AllocateMetaZone(std::mutex &metadata_reset_mtx,
-                         std::condition_variable &cv);
+  Zone *AllocateMetaZone();
 
   uint64_t GetFreeSpace();
   uint64_t GetUsedSpace();

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -59,6 +59,8 @@ Status zenfs_mount(ZonedBlockDevice *zbd, ZenFS **zenFS, bool readonly) {
     *zenFS = nullptr;
   }
 
+  // Wait till all reset tasks finished
+  std::unique_ptr<std::mutex> lk(zbd->metazone_reset_mtx);
   return s;
 }
 

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -14,8 +14,9 @@
 #include <sstream>
 
 #include <rocksdb/file_system.h>
-#include <rocksdb/plugin/zenfs/fs/fs_zenfs.h>
 #include <gflags/gflags.h>
+
+#include "fs/fs_zenfs.h"
 
 using GFLAGS_NAMESPACE::ParseCommandLineFlags;
 using GFLAGS_NAMESPACE::RegisterFlagValidator;


### PR DESCRIPTION
1. Plugin Path
We don't want to add a new plugin directory at the moment, so we remove all `plugin/` prefixes and the soft link scripts in TerarkDB.

2. `zenfs.mkfs` bug
- The previous async reset implementation works good but it passes mutex to function which is not a good practice.
- If the background reset is not finished, the zenfs.mkfs function will fail due to resource contention (it mount & replay metadata zones on startup and will re-open it immediately)
- So we move all mutex into `zbd` and make `mkfs` wait till all reset finished.
