### PR TITLE
add snapshot zones to zbd

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -227,6 +227,9 @@ ZenFS::~ZenFS() {
   LogFiles();
 
   meta_log_.reset(nullptr);
+#ifdef WITH_ZENFS_ASYNC_METAZONE_ROLLOVER
+  meta_snapshot_log_.reset(nullptr);
+#endif // WITH_ZENFS_ASYNC_METAZONE_ROLLOVER
   ClearFiles();
   delete zbd_;
 }

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -125,6 +125,7 @@ class ZenFS : public FileSystemWrapper {
 
   Zone* cur_meta_zone_ = nullptr;
   std::unique_ptr<ZenMetaLog> meta_log_;
+  std::unique_ptr<ZenMetaLog> meta_snapshot_log_;
   std::mutex metadata_sync_mtx_;
   std::unique_ptr<Superblock> superblock_;
 

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -141,6 +141,7 @@ class ZonedBlockDevice {
   std::mutex io_zones_mtx;
   std::mutex wal_zones_mtx;
   std::vector<Zone *> meta_zones;
+  std::vector<Zone *> meta_snapshot_zones;
   int read_f_;
   int read_direct_f_;
   int write_f_;
@@ -214,6 +215,7 @@ class ZonedBlockDevice {
   uint32_t GetMaxOpenZones() { return max_nr_open_io_zones_ + 1; };
 
   std::vector<Zone *> GetMetaZones() { return meta_zones; }
+  std::vector<Zone *> GetMetaSnapshotZones() { return meta_snapshot_zones; }
 
   void SetFinishTreshold(uint32_t threshold) { finish_threshold_ = threshold; }
 


### PR DESCRIPTION
This PR depends on This PR depends on https://github.com/bzbd/zenfs/pull/46. This PR contains a single commit. 

This PR
- added support facility for snapshot zone and guarded the usage with `WITH_ZENFS_ASYNC_METAZONE_ROLLOVER` flag
  - meta_snapshot_zones allocation and de-allocation, and helper function `GetMetaSnapshotZones()`.

- added unit test to make sure snapshot zones get allocated properly when open zbd
   -  if the flag is enabled, we expect to see `meta_snapshot_zones.size() == 2`
   - else `meta_snapshot_zones.size() == 0`, since original version should not init `meta_snapshot_zones`. 
