### PR TITLE
Add snapshot zone mount

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -904,7 +904,7 @@ Status ZenFS::RecoverFromSnapshotZone(ZenMetaLog* log) {
 }
 
 /* find the latest meta log */
-Status ZenFS::RecoverFromMetaZone(ZenMetaLog* log) {
+Status ZenFS::RecoverFromOpLogZone(ZenMetaLog* log) {
   bool found_one_metadata = false;
   std::string scratch;
   uint32_t tag = 0;
@@ -1340,7 +1340,7 @@ Status ZenFS::MountV2(bool readonly) {
     std::string scratch;
     std::unique_ptr<ZenMetaLog> log = std::move(valid_logs_metadata[i]);
 
-    s = RecoverFromMetaZone(log.get());
+    s = RecoverFromOpLogZone(log.get());
     if (!s.ok()) {
       if (s.IsNotFound()) {
         Warn(logger_,

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -782,7 +782,7 @@ Status ZenFS::DecodeSnapshotFrom(Slice* input) {
 
     files_.insert(std::make_pair(zoneFile->GetFilename(), zoneFile));
     if (zoneFile->GetID() >= next_file_id_)
-       next_file_id_ = zoneFile->GetID() + 1;
+      next_file_id_ = zoneFile->GetID() + 1;
   }
 
   return Status::OK();
@@ -1123,14 +1123,14 @@ Status ZenFS::Mount(bool readonly) {
   }
 
   Info(logger_, "Recovered from zone: %d", (int)valid_zones[r]->GetZoneNr());
-  superblock_ = std::move(valid_superblocks[r]);
-  zbd_->SetFinishTreshold(superblock_->GetFinishTreshold());
-  zbd_->SetMaxActiveZones(superblock_->GetMaxActiveZoneLimit());
-  zbd_->SetMaxOpenZones(superblock_->GetMaxOpenZoneLimit());
+  metadata_superblock_ = std::move(valid_superblocks[r]);
+  zbd_->SetFinishTreshold(metadata_superblock_->GetFinishTreshold());
+  zbd_->SetMaxActiveZones(metadata_superblock_->GetMaxActiveZoneLimit());
+  zbd_->SetMaxOpenZones(metadata_superblock_->GetMaxOpenZoneLimit());
 
   IOOptions foo;
   IODebugContext bar;
-  s = target()->CreateDirIfMissing(superblock_->GetAuxFsPath(), foo, &bar);
+  s = target()->CreateDirIfMissing(metadata_superblock_->GetAuxFsPath(), foo, &bar);
   if (!s.ok()) {
     Error(logger_, "Failed to create aux filesystem directory.");
     return s;
@@ -1160,8 +1160,8 @@ Status ZenFS::Mount(bool readonly) {
     files_mtx_.unlock();
   }
 
-  Info(logger_, "Superblock sequence %d", (int)superblock_->GetSeq());
-  Info(logger_, "Finish threshold %u", superblock_->GetFinishTreshold());
+  Info(logger_, "Superblock sequence %d", (int)metadata_superblock_->GetSeq());
+  Info(logger_, "Finish threshold %u", metadata_superblock_->GetFinishTreshold());
   Info(logger_, "Filesystem mount OK");
 
   if (!readonly) {

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -1174,7 +1174,7 @@ Status ZenFS::Mount(bool readonly) {
   return Status::OK();
 }
 
-Status ZenFS::ResetZone(std::vector<Zone*> const& zones, Zone* reset_zone,
+Status ZenFS::InitMetaZone(std::vector<Zone*> const& zones, Zone* reset_zone,
                         std::unique_ptr<ZenMetaLog>* log,
                         std::string const& aux_fs_path,
                         uint32_t const finish_threshold,
@@ -1246,7 +1246,7 @@ Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold,
   std::unique_ptr<ZenMetaLog> snapshot_log;
   Zone* reset_snapshot_zone = nullptr;
 
-  s = ResetZone(snapshot_zones, reset_snapshot_zone, &snapshot_log, aux_fs_path,
+  s = InitMetaZone(snapshot_zones, reset_snapshot_zone, &snapshot_log, aux_fs_path,
                 finish_threshold, max_open_limit, max_active_limit);
 
   if (!s.ok()) {
@@ -1262,7 +1262,7 @@ Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold,
   }
 #endif  // WITH_ZENFS_ASYNC_METAZONE_ROLLOVER
 
-  s = ResetZone(op_zones, reset_op_log_zone, &op_log, aux_fs_path,
+  s = InitMetaZone(op_zones, reset_op_log_zone, &op_log, aux_fs_path,
                 finish_threshold, max_open_limit, max_active_limit);
 
   if (!s.ok()) {
@@ -1270,7 +1270,7 @@ Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold,
     return Status::IOError("Failed to reset op log");
   }
 
-#if !defined(WITH_ZENFS_ASYNC_METAZONE_ROLLOVER)
+#ifndef WITH_ZENFS_ASYNC_METAZONE_ROLLOVER
   /* Write an empty snapshot to make the metadata zone valid */
   s = PersistSnapshot(op_log.get());
   if (!s.ok()) {

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -1189,16 +1189,10 @@ Status ZenFS::MountV2(bool readonly) {
   Status s;
 
   /* We need a minimum of two non-offline snapshot zones */
-  if (snapshot_zones.size() < 2) {
+  if (snapshot_zones.size() < 2 && op_zones.size() < 2) {
     Error(logger_,
-          "Need at least two non-offline snapshot zones to open for write");
-    return Status::NotSupported();
-  }
-
-  /* We need a minimum of two non-offline meta data zones */
-  if (op_zones.size() < 2) {
-    Error(logger_,
-          "Need at least two non-offline meta zones to open for write");
+          "Need at least two non-offline zones for snapshot and op log zones, "
+          "respectively, to open for write");
     return Status::NotSupported();
   }
 

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -1090,7 +1090,7 @@ Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold,
 
   for (const auto sz: snapshot_zones) {
     if (sz->Reset().ok()) {
-      if (!sz) snapshot_zone = sz;
+      if (!snapshot_zone) snapshot_zone = sz;
     } else {
       Warn(logger_, "Failed to reset snapshot zone\n");
     }

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -188,13 +188,18 @@ class ZenFS : public FileSystemWrapper {
   ZoneFile* GetFile(std::string fname);
   IOStatus DeleteFile(std::string fname);
 
+  Status findAllValidSuperblocks(const std::vector<Zone*>& zones,
+    std::vector<std::unique_ptr<Superblock>>& valid_superblocks,
+    std::vector<std::unique_ptr<ZenMetaLog>>& valid_logs,
+    std::vector<Zone*>& valid_zones,
+    std::vector<std::pair<uint32_t, uint32_t>>& seq_map);
+
  public:
   explicit ZenFS(ZonedBlockDevice* zbd, std::shared_ptr<FileSystem> aux_fs,
                  std::shared_ptr<Logger> logger);
   virtual ~ZenFS();
 
   Status Mount(bool readonly);
-  Status MountV2(bool readonly);
   Status MkFS(std::string aux_fs_path, uint32_t finish_threshold,
               uint32_t max_open_limit, uint32_t max_active_limit);
   Status MkFSV2(std::string aux_fs_path, uint32_t finish_threshold,

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -205,7 +205,7 @@ class ZenFS : public FileSystemWrapper {
       std::vector<Zone*>& valid_zones,
       std::vector<std::pair<uint32_t, uint32_t>>& seq_map);
 
-  Status ResetZone(std::vector<Zone*> const& zones, Zone* reset_zone,
+  Status InitMetaZone(std::vector<Zone*> const& zones, Zone* reset_zone,
                    std::unique_ptr<ZenMetaLog>* log,
                    std::string const& aux_fs_path,
                    uint32_t const finish_threshold,

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -172,7 +172,7 @@ class ZenFS : public FileSystemWrapper {
 
   Status RecoverFrom(ZenMetaLog* log);
   Status RecoverFromSnapshotZone(ZenMetaLog* log);
-  Status RecoverFromMetaZone(ZenMetaLog* log);
+  Status RecoverFromOpLogZone(ZenMetaLog* log);
 
   std::string ToAuxPath(std::string path) {
     return op_super_block_->GetAuxFsPath() + path;

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -124,11 +124,11 @@ class ZenFS : public FileSystemWrapper {
   std::atomic<uint64_t> next_file_id_;
 
   Zone* cur_meta_zone_ = nullptr;
-  std::unique_ptr<ZenMetaLog> meta_log_;
+  std::unique_ptr<ZenMetaLog> op_log_;
   std::unique_ptr<ZenMetaLog> snapshot_log_;
   std::mutex metadata_sync_mtx_;
-  std::unique_ptr<Superblock> snapshot_superblock_;
-  std::unique_ptr<Superblock> metadata_superblock_;
+  std::unique_ptr<Superblock> snapshot_super_block_;
+  std::unique_ptr<Superblock> op_super_block_;
 
   std::shared_ptr<Logger> GetLogger() { return logger_; }
 
@@ -175,12 +175,12 @@ class ZenFS : public FileSystemWrapper {
   Status RecoverFromMetaZone(ZenMetaLog* log);
 
   std::string ToAuxPath(std::string path) {
-    return metadata_superblock_->GetAuxFsPath() + path;
+    return op_super_block_->GetAuxFsPath() + path;
   }
 
   std::string ToZenFSPath(std::string aux_path) {
     std::string path = aux_path;
-    path.erase(0, metadata_superblock_->GetAuxFsPath().length());
+    path.erase(0, op_super_block_->GetAuxFsPath().length());
     return path;
   }
 

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -205,12 +205,14 @@ class ZenFS : public FileSystemWrapper {
       std::vector<Zone*>& valid_zones,
       std::vector<std::pair<uint32_t, uint32_t>>& seq_map);
 
-  Status InitMetaZone(std::vector<Zone*> const& zones, Zone* reset_zone,
-                   std::unique_ptr<ZenMetaLog>* log,
-                   std::string const& aux_fs_path,
-                   uint32_t const finish_threshold,
-                   uint32_t const max_open_limit,
-                   uint32_t const max_active_limit);
+  Status InitMetaZone(
+      std::vector<Zone*> const& zones, std::unique_ptr<ZenMetaLog>* log);
+
+  Status CreateEmptySuperBlock(std::unique_ptr<ZenMetaLog>* log,
+                               std::string const& aux_fs_path,
+                               uint32_t const finish_threshold,
+                               uint32_t const max_open_limit,
+                               uint32_t const max_active_limit);
 
  public:
   explicit ZenFS(ZonedBlockDevice* zbd, std::shared_ptr<FileSystem> aux_fs,

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -125,7 +125,7 @@ class ZenFS : public FileSystemWrapper {
 
   Zone* cur_meta_zone_ = nullptr;
   std::unique_ptr<ZenMetaLog> meta_log_;
-  std::unique_ptr<ZenMetaLog> meta_snapshot_log_;
+  std::unique_ptr<ZenMetaLog> snapshot_log_;
   std::mutex metadata_sync_mtx_;
   std::unique_ptr<Superblock> snapshot_superblock_;
   std::unique_ptr<Superblock> metadata_superblock_;
@@ -194,6 +194,7 @@ class ZenFS : public FileSystemWrapper {
   virtual ~ZenFS();
 
   Status Mount(bool readonly);
+  Status MountV2(bool readonly);
   Status MkFS(std::string aux_fs_path, uint32_t finish_threshold,
               uint32_t max_open_limit, uint32_t max_active_limit);
   std::map<std::string, Env::WriteLifeTimeHint> GetWriteLifeTimeHints();

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -166,6 +166,7 @@ class ZenFS : public FileSystemWrapper {
   void EncodeFileDeletionTo(ZoneFile* zoneFile, std::string* output);
 
   Status DecodeSnapshotFrom(Slice* input);
+  Status DecodeSnapshotFromV2(Slice* input);
   Status CacheFilesFromSnapshot(Slice* input);
   Status DecodeFileUpdateFrom(Slice* slice);
   Status DecodeFileDeletionFrom(Slice* slice);

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -166,8 +166,7 @@ class ZenFS : public FileSystemWrapper {
   void EncodeFileDeletionTo(ZoneFile* zoneFile, std::string* output);
 
   Status DecodeSnapshotFrom(Slice* input);
-  Status DecodeSnapshotFromV2(Slice* input);
-  Status CacheFilesFromSnapshot(Slice* input);
+  Status DecodeSnapshotFromAndNoCacheFiles(Slice* input);
   Status DecodeFileUpdateFrom(Slice* slice);
   Status DecodeFileDeletionFrom(Slice* slice);
 

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -166,6 +166,7 @@ class ZenFS : public FileSystemWrapper {
   void EncodeFileDeletionTo(ZoneFile* zoneFile, std::string* output);
 
   Status DecodeSnapshotFrom(Slice* input);
+  Status CacheFilesFromSnapshot(Slice* input);
   Status DecodeFileUpdateFrom(Slice* slice);
   Status DecodeFileDeletionFrom(Slice* slice);
 

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -197,6 +197,8 @@ class ZenFS : public FileSystemWrapper {
   Status MountV2(bool readonly);
   Status MkFS(std::string aux_fs_path, uint32_t finish_threshold,
               uint32_t max_open_limit, uint32_t max_active_limit);
+  Status MkFSV2(std::string aux_fs_path, uint32_t finish_threshold,
+              uint32_t max_open_limit, uint32_t max_active_limit);
   std::map<std::string, Env::WriteLifeTimeHint> GetWriteLifeTimeHints();
 
   const char* Name() const override {

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -188,11 +188,16 @@ class ZenFS : public FileSystemWrapper {
   ZoneFile* GetFile(std::string fname);
   IOStatus DeleteFile(std::string fname);
 
-  Status FindAllValidSuperblocks(const std::vector<Zone*>& zones,
+  Status FindAllValidSuperblocks(std::vector<Zone*> const & zones,
     std::vector<std::unique_ptr<Superblock>>& valid_superblocks,
     std::vector<std::unique_ptr<ZenMetaLog>>& valid_logs,
     std::vector<Zone*>& valid_zones,
     std::vector<std::pair<uint32_t, uint32_t>>& seq_map);
+
+  Status ResetZone(std::vector<Zone*> const & zones,
+    Zone* reset_zone, std::unique_ptr<ZenMetaLog>* log,
+    std::string const & aux_fs_path, uint32_t const finish_threshold,
+    uint32_t const max_open_limit, uint32_t const max_active_limit);
 
  public:
   explicit ZenFS(ZonedBlockDevice* zbd, std::shared_ptr<FileSystem> aux_fs,
@@ -201,8 +206,6 @@ class ZenFS : public FileSystemWrapper {
 
   Status Mount(bool readonly);
   Status MkFS(std::string aux_fs_path, uint32_t finish_threshold,
-              uint32_t max_open_limit, uint32_t max_active_limit);
-  Status MkFSV2(std::string aux_fs_path, uint32_t finish_threshold,
               uint32_t max_open_limit, uint32_t max_active_limit);
   std::map<std::string, Env::WriteLifeTimeHint> GetWriteLifeTimeHints();
 

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -127,7 +127,8 @@ class ZenFS : public FileSystemWrapper {
   std::unique_ptr<ZenMetaLog> meta_log_;
   std::unique_ptr<ZenMetaLog> meta_snapshot_log_;
   std::mutex metadata_sync_mtx_;
-  std::unique_ptr<Superblock> superblock_;
+  std::unique_ptr<Superblock> snapshot_superblock_;
+  std::unique_ptr<Superblock> metadata_superblock_;
 
   std::shared_ptr<Logger> GetLogger() { return logger_; }
 
@@ -171,12 +172,12 @@ class ZenFS : public FileSystemWrapper {
   Status RecoverFrom(ZenMetaLog* log);
 
   std::string ToAuxPath(std::string path) {
-    return superblock_->GetAuxFsPath() + path;
+    return metadata_superblock_->GetAuxFsPath() + path;
   }
 
   std::string ToZenFSPath(std::string aux_path) {
     std::string path = aux_path;
-    path.erase(0, superblock_->GetAuxFsPath().length());
+    path.erase(0, metadata_superblock_->GetAuxFsPath().length());
     return path;
   }
 

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -170,6 +170,8 @@ class ZenFS : public FileSystemWrapper {
   Status DecodeFileDeletionFrom(Slice* slice);
 
   Status RecoverFrom(ZenMetaLog* log);
+  Status RecoverFromSnapshotZone(ZenMetaLog* log);
+  Status RecoverFromMetaZone(ZenMetaLog* log);
 
   std::string ToAuxPath(std::string path) {
     return metadata_superblock_->GetAuxFsPath() + path;

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -150,6 +150,12 @@ class ZenFS : public FileSystemWrapper {
     kEndRecord = 4,
   };
 
+  enum RecoverType : uint8_t {
+    kBOTH = 1,
+    kSNAPSHOT = 2,
+    kOPLOG = 3,
+  };
+
   void LogFiles();
   void ClearFiles();
   IOStatus WriteSnapshotLocked(ZenMetaLog* meta_log);
@@ -165,11 +171,11 @@ class ZenFS : public FileSystemWrapper {
   void EncodeSnapshotTo(std::string* output);
   void EncodeFileDeletionTo(ZoneFile* zoneFile, std::string* output);
 
-  Status DecodeSnapshotFrom(Slice* input, bool cache_files);
+  Status DecodeSnapshotFrom(Slice* input);
   Status DecodeFileUpdateFrom(Slice* slice);
   Status DecodeFileDeletionFrom(Slice* slice);
 
-  Status RecoverFrom(ZenMetaLog* log);
+  Status RecoverFrom(ZenMetaLog* log, RecoverType type = RecoverType::kBOTH);
   Status RecoverFromSnapshotZone(ZenMetaLog* log);
   Status RecoverFromOpLogZone(ZenMetaLog* log);
 
@@ -187,21 +193,24 @@ class ZenFS : public FileSystemWrapper {
   ZoneFile* GetFile(std::string fname);
   IOStatus DeleteFile(std::string fname);
 
-  enum ZenFSZoneTag: uint32_t {
+  enum ZenFSZoneTag : uint32_t {
     kSnapshotZone = 1,
     kOpLogZone = 2,
   };
 
-  Status FindAllValidSuperblocks(ZenFSZoneTag zone_tag,
-    std::vector<std::unique_ptr<Superblock>>& valid_superblocks,
-    std::vector<std::unique_ptr<ZenMetaLog>>& valid_logs,
-    std::vector<Zone*>& valid_zones,
-    std::vector<std::pair<uint32_t, uint32_t>>& seq_map);
+  Status FindAllValidSuperblocks(
+      ZenFSZoneTag zone_tag,
+      std::vector<std::unique_ptr<Superblock>>& valid_superblocks,
+      std::vector<std::unique_ptr<ZenMetaLog>>& valid_logs,
+      std::vector<Zone*>& valid_zones,
+      std::vector<std::pair<uint32_t, uint32_t>>& seq_map);
 
-  Status ResetZone(std::vector<Zone*> const & zones,
-    Zone* reset_zone, std::unique_ptr<ZenMetaLog>* log,
-    std::string const & aux_fs_path, uint32_t const finish_threshold,
-    uint32_t const max_open_limit, uint32_t const max_active_limit);
+  Status ResetZone(std::vector<Zone*> const& zones, Zone* reset_zone,
+                   std::unique_ptr<ZenMetaLog>* log,
+                   std::string const& aux_fs_path,
+                   uint32_t const finish_threshold,
+                   uint32_t const max_open_limit,
+                   uint32_t const max_active_limit);
 
  public:
   explicit ZenFS(ZonedBlockDevice* zbd, std::shared_ptr<FileSystem> aux_fs,

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -188,7 +188,7 @@ class ZenFS : public FileSystemWrapper {
   ZoneFile* GetFile(std::string fname);
   IOStatus DeleteFile(std::string fname);
 
-  Status findAllValidSuperblocks(const std::vector<Zone*>& zones,
+  Status FindAllValidSuperblocks(const std::vector<Zone*>& zones,
     std::vector<std::unique_ptr<Superblock>>& valid_superblocks,
     std::vector<std::unique_ptr<ZenMetaLog>>& valid_logs,
     std::vector<Zone*>& valid_zones,

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -165,8 +165,7 @@ class ZenFS : public FileSystemWrapper {
   void EncodeSnapshotTo(std::string* output);
   void EncodeFileDeletionTo(ZoneFile* zoneFile, std::string* output);
 
-  Status DecodeSnapshotFrom(Slice* input);
-  Status DecodeSnapshotFromAndNoCacheFiles(Slice* input);
+  Status DecodeSnapshotFrom(Slice* input, bool cache_files);
   Status DecodeFileUpdateFrom(Slice* slice);
   Status DecodeFileDeletionFrom(Slice* slice);
 

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -187,7 +187,12 @@ class ZenFS : public FileSystemWrapper {
   ZoneFile* GetFile(std::string fname);
   IOStatus DeleteFile(std::string fname);
 
-  Status FindAllValidSuperblocks(std::vector<Zone*> const & zones,
+  enum ZenFSZoneTag: uint32_t {
+    kSnapshotZone = 1,
+    kOpLogZone = 2,
+  };
+
+  Status FindAllValidSuperblocks(ZenFSZoneTag zone_tag,
     std::vector<std::unique_ptr<Superblock>>& valid_superblocks,
     std::vector<std::unique_ptr<ZenMetaLog>>& valid_logs,
     std::vector<Zone*>& valid_zones,

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -39,12 +39,12 @@
 #define ZENFS_DEBUG
 #include "utils.h"
 
-/* Number of reserved zones for metadata
- * Two non-offline meta zones are needed to be able
- * to roll the metadata log safely. One extra
+/* Number of reserved zones for op log
+ * Two non-offline op log zones are needed to be able
+ * to roll the log safely. One extra
  * is allocated to cover for one zone going offline.
  */
-#define ZENFS_META_ZONES (4)
+#define ZENFS_OP_LOG_ZONES (4)
 
 /* Number of reserved zones for metadata snapshot
  */
@@ -523,7 +523,7 @@ IOStatus ZonedBlockDevice::Open(bool readonly) {
     return IOStatus::IOError("Failed to list zones");
   }
 
-  while (m < ZENFS_META_ZONES && i < reported_zones) {
+  while (m < ZENFS_OP_LOG_ZONES && i < reported_zones) {
     struct zbd_zone *z = &zone_rep[i++];
     /* Only use sequential write required zones */
     if (zbd_zone_type(z) == ZBD_ZONE_TYPE_SWR) {

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -541,7 +541,7 @@ IOStatus ZonedBlockDevice::Open(bool readonly) {
     /* Only use sequential write required zones */
     if (zbd_zone_type(z) == ZBD_ZONE_TYPE_SWR) {
       if (!zbd_zone_offline(z)) {
-        meta_snapshot_zones.push_back(new Zone(this, z));
+        snapshot_zones.push_back(new Zone(this, z));
       }
       snapshot_zones_num++;
     }
@@ -656,7 +656,7 @@ ZonedBlockDevice::~ZonedBlockDevice() {
   }
 
 #ifdef WITH_ZENFS_ASYNC_METAZONE_ROLLOVER
-  for (const auto z : meta_snapshot_zones) {
+  for (const auto z : snapshot_zones) {
     delete z;
   }
 #endif
@@ -943,7 +943,7 @@ void ZonedBlockDevice::EncodeJson(std::ostream &json_stream) {
   EncodeJsonZone(json_stream, meta_zones);
 #ifdef WITH_ZENFS_ASYNC_METAZONE_ROLLOVER
   json_stream << "\"meta snapshot\":";
-  EncodeJsonZone(json_stream, meta_snapshot_zones);
+  EncodeJsonZone(json_stream, snapshot_zones);
 #endif // WITH_ZENFS_ASYNC_METAZONE_ROLLOVER
   json_stream << ",\"io\":";
   EncodeJsonZone(json_stream, io_zones);

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -141,7 +141,7 @@ class ZonedBlockDevice {
   std::mutex io_zones_mtx;
   std::mutex wal_zones_mtx;
   // meta log zones used to keep track of running record of metadata
-  std::vector<Zone *> meta_zones;
+  std::vector<Zone *> op_zones;
   // snapshot zones used to recover entire file system
   std::vector<Zone *> snapshot_zones;
   int read_f_;
@@ -216,7 +216,7 @@ class ZonedBlockDevice {
   uint32_t GetMaxActiveZones() { return max_nr_active_io_zones_ + 1; };
   uint32_t GetMaxOpenZones() { return max_nr_open_io_zones_ + 1; };
 
-  std::vector<Zone *> GetMetaZones() { return meta_zones; }
+  std::vector<Zone *> GetOpZones() { return op_zones; }
   std::vector<Zone *> GetSnapshotZones() { return snapshot_zones; }
 
   void SetFinishTreshold(uint32_t threshold) { finish_threshold_ = threshold; }

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -140,8 +140,10 @@ class ZonedBlockDevice {
   std::vector<Zone *> io_zones;
   std::mutex io_zones_mtx;
   std::mutex wal_zones_mtx;
+  // meta log zones used to keep track of running record of metadata
   std::vector<Zone *> meta_zones;
-  std::vector<Zone *> meta_snapshot_zones;
+  // snapshot zones used to recover entire file system
+  std::vector<Zone *> snapshot_zones;
   int read_f_;
   int read_direct_f_;
   int write_f_;
@@ -215,7 +217,7 @@ class ZonedBlockDevice {
   uint32_t GetMaxOpenZones() { return max_nr_open_io_zones_ + 1; };
 
   std::vector<Zone *> GetMetaZones() { return meta_zones; }
-  std::vector<Zone *> GetMetaSnapshotZones() { return meta_snapshot_zones; }
+  std::vector<Zone *> GetSnapshotZones() { return snapshot_zones; }
 
   void SetFinishTreshold(uint32_t threshold) { finish_threshold_ = threshold; }
 

--- a/test/backgroundWorker_test.cc
+++ b/test/backgroundWorker_test.cc
@@ -2,8 +2,8 @@
 #include <fcntl.h>
 #include <gflags/gflags.h>
 #include <rocksdb/file_system.h>
-#include <rocksdb/plugin/zenfs/fs/fs_zenfs.h>
-#include <rocksdb/plugin/zenfs/fs/zbd_zenfs.h>
+#include <fs/fs_zenfs.h>
+#include <fs/zbd_zenfs.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 

--- a/test/utils.h
+++ b/test/utils.h
@@ -22,6 +22,15 @@ using GFLAGS_NAMESPACE::RegisterFlagValidator;
 using GFLAGS_NAMESPACE::SetUsageMessage;
 
 DEFINE_string(zbd, "", "Path to a zoned block device.");
+DEFINE_string(aux_path, "",
+"Path for auxiliary file storage (log and lock files).");
+DEFINE_bool(force, false, "Force file system creation.");
+DEFINE_string(path, "", "File path");
+DEFINE_int32(finish_threshold, 0, "Finish used zones if less than x% left");
+DEFINE_string(restore_path, "", "Path to restore files");
+DEFINE_string(backup_path, "", "Path to backup files");
+DEFINE_int32(max_active_zones, 0, "Max active zone limit");
+DEFINE_int32(max_open_zones, 0, "Max active zone limit");
 
 bool find_sub_string(std::string const& inputString, std::string const& subString) {
   std::size_t found = inputString.find(subString);

--- a/test/utils.h
+++ b/test/utils.h
@@ -2,12 +2,10 @@
 #include <fcntl.h>
 #include <gflags/gflags.h>
 #include <rocksdb/file_system.h>
-#include <third-party/zenfs/fs/fs_zenfs.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
 #include <atomic>
-#include <boost/fiber/buffered_channel.hpp>
 #include <cmath>
 #include <cstdio>
 #include <fstream>
@@ -17,13 +15,15 @@
 #include <streambuf>
 #include <thread>
 
+#include <fs/fs_zenfs.h>
+
 using GFLAGS_NAMESPACE::ParseCommandLineFlags;
 using GFLAGS_NAMESPACE::RegisterFlagValidator;
 using GFLAGS_NAMESPACE::SetUsageMessage;
 
 DEFINE_string(zbd, "", "Path to a zoned block device.");
 DEFINE_string(aux_path, "",
-"Path for auxiliary file storage (log and lock files).");
+              "Path for auxiliary file storage (log and lock files).");
 DEFINE_bool(force, false, "Force file system creation.");
 DEFINE_string(path, "", "File path");
 DEFINE_int32(finish_threshold, 0, "Finish used zones if less than x% left");
@@ -32,9 +32,10 @@ DEFINE_string(backup_path, "", "Path to backup files");
 DEFINE_int32(max_active_zones, 0, "Max active zone limit");
 DEFINE_int32(max_open_zones, 0, "Max active zone limit");
 
-bool find_sub_string(std::string const& inputString, std::string const& subString) {
+bool find_sub_string(std::string const &inputString,
+                     std::string const &subString) {
   std::size_t found = inputString.find(subString);
-  if (found!=std::string::npos) {
+  if (found != std::string::npos) {
     return false;
   }
 
@@ -59,7 +60,8 @@ ZonedBlockDevice *zbd_open(bool readonly, std::shared_ptr<Logger> logger) {
   return zbd;
 }
 
-Status zenfs_mount(ZonedBlockDevice *zbd, ZenFS **zenFS, bool readonly, std::shared_ptr<Logger> logger) {
+Status zenfs_mount(ZonedBlockDevice *zbd, ZenFS **zenFS, bool readonly,
+                   std::shared_ptr<Logger> logger) {
   Status s;
 
   *zenFS = new ZenFS(zbd, FileSystem::Default(), logger);
@@ -82,4 +84,4 @@ static std::string GetLogFilename(std::string bdev) {
 
   return ss.str();
 }
-}
+}  // namespace ROCKSDB_NAMESPACE

--- a/test/zenfs_metazone_rollover_test.cc
+++ b/test/zenfs_metazone_rollover_test.cc
@@ -45,17 +45,17 @@ int test_snapshot_zone_allocation() {
   ZonedBlockDevice *zbd = zbd_open(false, logger);
   if (zbd == nullptr) return 1;
 
-  auto meta_snapshot_zones = zbd->GetMetaSnapshotZones();
+  auto snapshot_zones = zbd->GetSnapshotZones();
   
 #ifdef WITH_ZENFS_ASYNC_METAZONE_ROLLOVER
   const int zenfs_snapshot_zones_num = 2;
-  if (meta_snapshot_zones.size() != zenfs_snapshot_zones_num) {
-    fprintf(stderr, "Error! Failed to allocate meta snapshot zone");
+  if (snapshot_zones.size() != zenfs_snapshot_zones_num) {
+    fprintf(stderr, "Error! Failed to allocate snapshot zone");
     return 1;
   }
 #else
-  if (meta_snapshot_zones.size() == 0) {
-    std::cout << "Success! Did not allocate meta snapshot zone\n";
+  if (snapshot_zones.size() == 0) {
+    std::cout << "Success! Did not allocate snapshot zone\n";
     return 0;
   }
 #endif

--- a/test/zenfs_metazone_rollover_test.cc
+++ b/test/zenfs_metazone_rollover_test.cc
@@ -79,7 +79,7 @@ int test_mkfs() {
     FLAGS_aux_path.append("/");
   }
 
-  s = zenFS->MkFSV2(FLAGS_aux_path, FLAGS_finish_threshold,
+  s = zenFS->MkFS(FLAGS_aux_path, FLAGS_finish_threshold,
                   FLAGS_max_open_zones, FLAGS_max_active_zones);
   if (!s.ok()) {
     fprintf(stderr, "Failed to create file system, error: %s\n",

--- a/test/zenfs_metazone_rollover_test.cc
+++ b/test/zenfs_metazone_rollover_test.cc
@@ -14,7 +14,10 @@ int test_metadata_rollover() {
   }
 
   ZonedBlockDevice *zbd = zbd_open(false, logger);
-  if (zbd == nullptr) return 1;
+  if (zbd == nullptr) {
+    fprintf(stderr, "Failed to open file\n");;
+    return 1;
+  }
 
   ZenFS *zenFS;
   s = zenfs_mount(zbd, &zenFS, false, logger);
@@ -31,35 +34,69 @@ int test_metadata_rollover() {
   return 0;
 }
 
-int test_snapshot_zone_allocation() {
-  std::shared_ptr<Logger> logger;
+int test_mkfs() {
   Status s;
+  DIR* aux_dir;
+  std::shared_ptr<Logger> logger;
+
+  if (FLAGS_aux_path.empty()) {
+      fprintf(stderr, "You need to specify --aux_path\n");
+      return 1;
+  }
+
+  aux_dir = opendir(FLAGS_aux_path.c_str());
+  if (ENOENT != errno) {
+      fprintf(stderr, "Error: aux path exists\n");
+      closedir(aux_dir);
+      return 1;
+  }
 
   s = Env::Default()->NewLogger(GetLogFilename(FLAGS_zbd), &logger);
   if (!s.ok()) {
-    fprintf(stderr, "ZenFS: Could not create logger");
+      fprintf(stderr, "ZenFS: Could not create logger");
   } else {
-    logger->SetInfoLogLevel(DEBUG_LEVEL);
+      logger->SetInfoLogLevel(DEBUG_LEVEL);
   }
 
   ZonedBlockDevice *zbd = zbd_open(false, logger);
-  if (zbd == nullptr) return 1;
+  if (zbd == nullptr) {
+      fprintf(stderr, "Failed to open file\n");;
+      return 1;
+  }
 
+  /* verify if snapshot zones being allocated properly */
   auto snapshot_zones = zbd->GetSnapshotZones();
-  
-#ifdef WITH_ZENFS_ASYNC_METAZONE_ROLLOVER
   const int zenfs_snapshot_zones_num = 2;
   if (snapshot_zones.size() != zenfs_snapshot_zones_num) {
     fprintf(stderr, "Error! Failed to allocate snapshot zone");
     return 1;
   }
-#else
-  if (snapshot_zones.size() == 0) {
-    std::cout << "Success! Did not allocate snapshot zone\n";
-    return 0;
-  }
-#endif
 
+  ZenFS *zenFS;
+  zenFS = new ZenFS(zbd, FileSystem::Default(), logger);
+
+  if (FLAGS_aux_path.back() != '/') FLAGS_aux_path.append("/");
+
+  s = zenFS->MkFS(FLAGS_aux_path, FLAGS_finish_threshold,
+                  FLAGS_max_open_zones, FLAGS_max_active_zones);
+  if (!s.ok()) {
+    fprintf(stderr, "Failed to create file system, error: %s\n",
+            s.ToString().c_str());
+    delete zenFS;
+    return 1;
+  }
+
+  /* verify if the fist snapshot zone has an empty snapshot record */
+  assert(!snapshot_zones[0].IsEmpty());
+  /* verify if the reset of snapshot zones are reset properly */
+  for (int i = 1; i < snapshot_zones.size(); i++) {
+    assert(snapshot_zones[i].IsEmpty());
+  }
+
+  fprintf(stdout, "ZenFS file system created. Free space: %lu MB\n",
+          zbd->GetFreeSpace() / (1024 * 1024));
+
+  delete zenFS;
   return 0;
 }
 
@@ -73,7 +110,7 @@ int main(int argc, char **argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   ROCKSDB_NAMESPACE::test_metadata_rollover();
-  ROCKSDB_NAMESPACE::test_snapshot_zone_allocation();
+  ROCKSDB_NAMESPACE::test_mkfs();
 
   return 0;
 }

--- a/test/zenfs_metazone_rollover_test.cc
+++ b/test/zenfs_metazone_rollover_test.cc
@@ -75,7 +75,9 @@ int test_mkfs() {
   ZenFS *zenFS;
   zenFS = new ZenFS(zbd, FileSystem::Default(), logger);
 
-  if (FLAGS_aux_path.back() != '/') FLAGS_aux_path.append("/");
+  if (FLAGS_aux_path.back() != '/') {
+    FLAGS_aux_path.append("/");
+  }
 
   s = zenFS->MkFSV2(FLAGS_aux_path, FLAGS_finish_threshold,
                   FLAGS_max_open_zones, FLAGS_max_active_zones);

--- a/test/zenfs_metazone_rollover_test.cc
+++ b/test/zenfs_metazone_rollover_test.cc
@@ -87,10 +87,10 @@ int test_mkfs() {
   }
 
   /* verify if the fist snapshot zone has an empty snapshot record */
-  assert(!snapshot_zones[0].IsEmpty());
+  assert(!snapshot_zones[0]->IsEmpty());
   /* verify if the reset of snapshot zones are reset properly */
   for (int i = 1; i < snapshot_zones.size(); i++) {
-    assert(snapshot_zones[i].IsEmpty());
+    assert(snapshot_zones[i]->IsEmpty());
   }
 
   fprintf(stdout, "ZenFS file system created. Free space: %lu MB\n",

--- a/test/zenfs_metazone_rollover_test.cc
+++ b/test/zenfs_metazone_rollover_test.cc
@@ -77,7 +77,7 @@ int test_mkfs() {
 
   if (FLAGS_aux_path.back() != '/') FLAGS_aux_path.append("/");
 
-  s = zenFS->MkFS(FLAGS_aux_path, FLAGS_finish_threshold,
+  s = zenFS->MkFSV2(FLAGS_aux_path, FLAGS_finish_threshold,
                   FLAGS_max_open_zones, FLAGS_max_active_zones);
   if (!s.ok()) {
     fprintf(stderr, "Failed to create file system, error: %s\n",

--- a/test/zenfs_metazone_rollover_test.cc
+++ b/test/zenfs_metazone_rollover_test.cc
@@ -15,7 +15,8 @@ int test_metadata_rollover() {
 
   ZonedBlockDevice *zbd = zbd_open(false, logger);
   if (zbd == nullptr) {
-    fprintf(stderr, "Failed to open file\n");;
+    fprintf(stderr, "Failed to open file\n");
+    ;
     return 1;
   }
 
@@ -23,11 +24,13 @@ int test_metadata_rollover() {
   s = zenfs_mount(zbd, &zenFS, false, logger);
   if (!s.ok()) {
 #ifdef WITH_ZENFS_ASYNC_METAZONE_ROLLOVER
-    assert(find_sub_string(s.ToString().c_str(), "Calling experimental function "
-                                                 "ZenFS::RollMetaZoneAsync()"));
+    assert(find_sub_string(s.ToString().c_str(),
+                           "Calling experimental function "
+                           "ZenFS::RollMetaZoneAsync()"));
     return 0;
 #endif
-    fprintf(stderr, "Failed to mount filesystem, error: %s\n", s.ToString().c_str());
+    fprintf(stderr, "Failed to mount filesystem, error: %s\n",
+            s.ToString().c_str());
     return 1;
   }
 
@@ -36,32 +39,33 @@ int test_metadata_rollover() {
 
 int test_mkfs() {
   Status s;
-  DIR* aux_dir;
+  DIR *aux_dir;
   std::shared_ptr<Logger> logger;
 
   if (FLAGS_aux_path.empty()) {
-      fprintf(stderr, "You need to specify --aux_path\n");
-      return 1;
+    fprintf(stderr, "You need to specify --aux_path\n");
+    return 1;
   }
 
   aux_dir = opendir(FLAGS_aux_path.c_str());
   if (ENOENT != errno) {
-      fprintf(stderr, "Error: aux path exists\n");
-      closedir(aux_dir);
-      return 1;
+    fprintf(stderr, "Error: aux path exists\n");
+    closedir(aux_dir);
+    return 1;
   }
 
   s = Env::Default()->NewLogger(GetLogFilename(FLAGS_zbd), &logger);
   if (!s.ok()) {
-      fprintf(stderr, "ZenFS: Could not create logger");
+    fprintf(stderr, "ZenFS: Could not create logger");
   } else {
-      logger->SetInfoLogLevel(DEBUG_LEVEL);
+    logger->SetInfoLogLevel(DEBUG_LEVEL);
   }
 
   ZonedBlockDevice *zbd = zbd_open(false, logger);
   if (zbd == nullptr) {
-      fprintf(stderr, "Failed to open file\n");;
-      return 1;
+    fprintf(stderr, "Failed to open file\n");
+    ;
+    return 1;
   }
 
   /* verify if snapshot zones being allocated properly */
@@ -79,8 +83,8 @@ int test_mkfs() {
     FLAGS_aux_path.append("/");
   }
 
-  s = zenFS->MkFS(FLAGS_aux_path, FLAGS_finish_threshold,
-                  FLAGS_max_open_zones, FLAGS_max_active_zones);
+  s = zenFS->MkFS(FLAGS_aux_path, FLAGS_finish_threshold, FLAGS_max_open_zones,
+                  FLAGS_max_active_zones);
   if (!s.ok()) {
     fprintf(stderr, "Failed to create file system, error: %s\n",
             s.ToString().c_str());


### PR DESCRIPTION
This PR:
- modify `MKFS`
  - write an empty snapshot record in snapshot zone instead of metazone
  - write an empty superblock both in snapshot and metadata zones

- add MKFS tests
  - ensure first snapshot zone is not empty (since it has an empty snapshot) and rest of snapshot zones are empty

- Modify `Mount` for snapshot and metadata zones
  - Recover from the snapshot zone with the highest superblock sequence number. Within that zone, we find the latest snapshot record.
  - recover from the metadata zone the highest superblock sequence number. Within that zone, we find the latest metadata record.

- added `RecoverFromSnapshotZone` and `RecoverFromMetaZone` functions.
  - most of the logic are the same from `RecoverFrom` function except 1) the `break` condition is changed to `continue` and 2) delete a case (left questions for now).

This PR is not intended to add metadata and snapshot rollover functions