### PR TITLE
add reporter for zbd disk utilization

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -385,8 +385,7 @@ IOStatus ZenFS::RollMetaZoneLocked(bool async) {
       assert(false);
     }
 
-    Info(logger_, "zbd free space %lu MB RollMetaZoneLocked\n", zbd_->GetFreeSpace() / (1024 * 1024));
-    zbd_->zbd_free_space_reporter_.AddRecord(zbd_->GetFreeSpace() / (1024 * 1024));
+    zbd_->ReportSpaceUtilization();
 
     // finish write and reset old op log zone
     auto old_op_zone = old_op_log->GetZone();
@@ -1129,8 +1128,7 @@ Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold,
     return Status::IOError("Failed to reset snapshot");
   }
 
-  Info(logger_, "zbd free space %lu MB MkFS\n", zbd_->GetFreeSpace() / (1024 * 1024));
-  zbd_->zbd_free_space_reporter_.AddRecord(zbd_->GetFreeSpace() / (1024 * 1024));
+  zbd_->ReportSpaceUtilization();
 
   // Reset all used opreation log zones and get one for writing a new super block.
   reset_zone = nullptr;

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -375,6 +375,7 @@ static std::string open_zones_metric_name = "zenfs_open_zones";
 static std::string zbd_free_space_metric_name = "zenfs_free_space";
 static std::string zbd_used_space_metric_name = "zenfs_used_space";
 static std::string zbd_reclaimable_space_metric_name = "zenfs_reclaimable_space";
+static std::string zbd_total_extent_length_metric_name = "zenfs_total_extent_length";
 
 ZonedBlockDevice::ZonedBlockDevice(std::string bdevname, std::shared_ptr<Logger> logger, std::string bytedance_tags,
                                    std::shared_ptr<MetricsReporterFactory> metrics_reporter_factory)
@@ -433,8 +434,10 @@ ZonedBlockDevice::ZonedBlockDevice(std::string bdevname, std::shared_ptr<Logger>
       zbd_used_space_reporter_(*metrics_reporter_factory_->BuildHistReporter(
           zbd_used_space_metric_name, bytedance_tags_)),
       zbd_reclaimable_space_reporter_(*metrics_reporter_factory_->BuildHistReporter(
-          zbd_reclaimable_space_metric_name, bytedance_tags_)) {
-  Info(logger_, "New Zoned Block Device: %s (with metrics enabled)",
+          zbd_reclaimable_space_metric_name, bytedance_tags_)),
+      zbd_total_extent_length_reporter_(*metrics_reporter_factory_->BuildHistReporter(
+          zbd_total_extent_length_metric_name, bytedance_tags_)) {
+    Info(logger_, "New Zoned Block Device: %s (with metrics enabled)",
        filename_.c_str());
 }
 

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -617,14 +617,14 @@ uint64_t ZonedBlockDevice::GetReclaimableSpace() {
 }
 
 void ZonedBlockDevice::ReportSpaceUtilization() {
-  Info(logger_, "zbd free space %lu MB MkFS\n", GetFreeSpace() / (1024 * 1024));
-  zbd_free_space_reporter_.AddRecord(GetFreeSpace() / (1024 * 1024));
+  Info(logger_, "zbd free space %lu GB MkFS\n", GetFreeSpace() / (1024 * 1024 * 1024));
+  zbd_free_space_reporter_.AddRecord(GetFreeSpace() / (1024 * 1024 * 1024));
 
-  Info(logger_, "zbd used space %lu MB MkFS\n", GetUsedSpace() / (1024 * 1024));
-  zbd_used_space_reporter_.AddRecord(GetUsedSpace() / (1024 * 1024));
+  Info(logger_, "zbd used space %lu GB MkFS\n", GetUsedSpace() / (1024 * 1024 * 1024));
+  zbd_used_space_reporter_.AddRecord(GetUsedSpace() / (1024 * 1024 * 1024));
 
-  Info(logger_, "zbd reclaimable space %lu MB MkFS\n", GetUsedSpace() / (1024 * 1024));
-  zbd_reclaimable_space_reporter_.AddRecord(GetReclaimableSpace() / (1024 * 1024));
+  Info(logger_, "zbd reclaimable space %lu GB MkFS\n", GetUsedSpace() / (1024 * 1024 * 1024));
+  zbd_reclaimable_space_reporter_.AddRecord(GetReclaimableSpace() / (1024 * 1024 * 1024));
 }
 
 void ZonedBlockDevice::LogZoneStats() {
@@ -712,7 +712,7 @@ unsigned int GetLifeTimeDiff(Env::WriteLifeTimeHint zone_lifetime, Env::WriteLif
 Zone *ZonedBlockDevice::AllocateMetaZone() {
   LatencyHistGuard guard(&meta_alloc_latency_reporter_);
   meta_alloc_qps_reporter_.AddCount(1);
-  
+
   for (const auto z : op_zones_) {
     if (z->IsEmpty()) {
       return z;
@@ -794,7 +794,7 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
     wal_zone_allocating_--;
   }
   LatencyHistGuard guard_actual(reporter_actual);
-  
+
   auto t1 = std::chrono::system_clock::now();
 
   /* Reset any unused zones and finish used zones under capacity treshold*/

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -372,6 +372,7 @@ static std::string roll_throughput_metric_name = "zenfs_roll_throughput";
 
 static std::string active_zones_metric_name = "zenfs_active_zones";
 static std::string open_zones_metric_name = "zenfs_open_zones";
+static std::string zbd_free_space_metric_name = "zenfs_free_space";
 
 ZonedBlockDevice::ZonedBlockDevice(std::string bdevname, std::shared_ptr<Logger> logger, std::string bytedance_tags,
                                    std::shared_ptr<MetricsReporterFactory> metrics_reporter_factory)
@@ -424,7 +425,9 @@ ZonedBlockDevice::ZonedBlockDevice(std::string bdevname, std::shared_ptr<Logger>
       active_zones_reporter_(*metrics_reporter_factory_->BuildHistReporter(
           active_zones_metric_name, bytedance_tags_)),
       open_zones_reporter_(*metrics_reporter_factory_->BuildHistReporter(
-          open_zones_metric_name, bytedance_tags_)) {
+          open_zones_metric_name, bytedance_tags_)),
+      zbd_free_space_reporter_(*metrics_reporter_factory_->BuildHistReporter(
+          zbd_free_space_metric_name, bytedance_tags_)) {
   Info(logger_, "New Zoned Block Device: %s (with metrics enabled)",
        filename_.c_str());
 }

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -216,6 +216,7 @@ class ZonedBlockDevice {
   uint64_t GetFreeSpace();
   uint64_t GetUsedSpace();
   uint64_t GetReclaimableSpace();
+  void ReportSpaceUtilization();
 
   std::string GetFilename();
   uint32_t GetBlockSize();
@@ -298,6 +299,8 @@ class ZonedBlockDevice {
   DataReporter active_zones_reporter_;
   DataReporter open_zones_reporter_;
   DataReporter zbd_free_space_reporter_;
+  DataReporter zbd_used_space_reporter_;
+  DataReporter zbd_reclaimable_space_reporter_;
 
   std::unique_ptr<BackgroundWorker> meta_worker_;
 

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -297,6 +297,7 @@ class ZonedBlockDevice {
   using DataReporter = HistReporterHandle &;
   DataReporter active_zones_reporter_;
   DataReporter open_zones_reporter_;
+  DataReporter zbd_free_space_reporter_;
 
   std::unique_ptr<BackgroundWorker> meta_worker_;
 

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -301,6 +301,7 @@ class ZonedBlockDevice {
   DataReporter zbd_free_space_reporter_;
   DataReporter zbd_used_space_reporter_;
   DataReporter zbd_reclaimable_space_reporter_;
+  DataReporter zbd_total_extent_length_reporter_;
 
   std::unique_ptr<BackgroundWorker> meta_worker_;
 


### PR DESCRIPTION
Adding reporter to collect zbd disk utilization when we finish writing a snapshot:
- file extents length 
- free space
- used space
- reclaimable space