### PR TITLE
Sync diagnosis

### DIFF
--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -492,7 +492,9 @@ IOStatus ZonedWritableFile::Truncate(uint64_t size,
 IOStatus ZonedWritableFile::Fsync(const IOOptions& /*options*/,
                                   IODebugContext* /*dbg*/) {
   IOStatus s;
-  LatencyHistGuard guard(&zoneFile_->GetZbd()->sync_latency_reporter_);
+  LatencyHistGuard guard(zoneFile_->is_wal_
+                             ? &zoneFile_->GetZbd()->fg_sync_latency_reporter_
+                             : &zoneFile_->GetZbd()->bg_sync_latency_reporter_);
   zoneFile_->GetZbd()->sync_qps_reporter_.AddCount(1);
 
   buffer_mtx_.lock();

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -466,12 +466,9 @@ ZonedWritableFile::ZonedWritableFile(ZonedBlockDevice* zbd, bool _buffered,
 }
 
 IOStatus ZoneFile::Sync() {
-  IOStatus s;
-  if (active_zone_) {
-    s = active_zone_->Sync();
-    if (!s.ok()) return s;
-  }
-  return s;
+  if (active_zone_)
+    return active_zone_->Sync();
+  return IOStatus::OK();
 }
 
 ZonedWritableFile::~ZonedWritableFile() {

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -351,7 +351,8 @@ ZonedBlockDevice::ZonedBlockDevice(std::string bdevname, std::shared_ptr<Logger>
 
 static std::string write_latency_metric_name = "zenfs_write_latency";
 static std::string read_latency_metric_name = "zenfs_read_latency";
-static std::string sync_latency_metric_name = "zenfs_sync_latency";
+static std::string fg_sync_latency_metric_name = "fg_zenfs_sync_latency";
+static std::string bg_sync_latency_metric_name = "bg_zenfs_sync_latency";
 static std::string io_alloc_wal_latency_metric_name = "zenfs_io_alloc_wal_latency";
 static std::string io_alloc_non_wal_latency_metric_name = "zenfs_io_alloc_non_wal_latency";
 static std::string io_alloc_wal_actual_latency_metric_name = "zenfs_io_alloc_wal_actual_latency";
@@ -387,8 +388,10 @@ ZonedBlockDevice::ZonedBlockDevice(std::string bdevname, std::shared_ptr<Logger>
           *metrics_reporter_factory_->BuildHistReporter(write_latency_metric_name, bytedance_tags_)),
       read_latency_reporter_(
           *metrics_reporter_factory_->BuildHistReporter(read_latency_metric_name, bytedance_tags_)),
-      sync_latency_reporter_(
-          *metrics_reporter_factory_->BuildHistReporter(sync_latency_metric_name, bytedance_tags_)),
+      fg_sync_latency_reporter_(
+          *metrics_reporter_factory_->BuildHistReporter(fg_sync_latency_metric_name, bytedance_tags_)),
+      bg_sync_latency_reporter_(
+          *metrics_reporter_factory_->BuildHistReporter(bg_sync_latency_metric_name, bytedance_tags_)),
       meta_alloc_latency_reporter_(
           *metrics_reporter_factory_->BuildHistReporter(
               meta_alloc_latency_metric_name, bytedance_tags_)),

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -501,8 +501,8 @@ IOStatus ZonedBlockDevice::Open(bool readonly) {
 
   /* We need 3 open zones for meta data writes , the rest can be used for files
    */
-  max_nr_active_io_zones_ = 10;
-  max_nr_open_io_zones_ = 11;
+  max_nr_active_io_zones_ = info.max_nr_active_zones - 3;
+  max_nr_open_io_zones_ = info.max_nr_active_zones - 3;
 
   Info(logger_, "Zone block device nr zones: %u max active: %u max open: %u \n", info.nr_zones,
        info.max_nr_active_zones, info.max_nr_open_zones);

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -273,7 +273,8 @@ class ZonedBlockDevice {
   using LatencyReporter = HistReporterHandle &;
   LatencyReporter write_latency_reporter_;
   LatencyReporter read_latency_reporter_;
-  LatencyReporter sync_latency_reporter_;
+  LatencyReporter fg_sync_latency_reporter_;
+  LatencyReporter bg_sync_latency_reporter_;
   LatencyReporter meta_alloc_latency_reporter_;
   LatencyReporter io_alloc_wal_latency_reporter_;
   LatencyReporter io_alloc_wal_actual_latency_reporter_;

--- a/test/backgroundWorker_test.cc
+++ b/test/backgroundWorker_test.cc
@@ -102,6 +102,7 @@ int test_background_worker_usage() {
         executor, zone_numbers[i], error_handler
     ));
   }
+  return 0;
 }
 }  // namespace ROCKSDB_NAMESPACE
 


### PR DESCRIPTION
Diagnosis sync spike latency.
If spike latency was only happening in the background, we could trace that out and ignore.
If it happens in the foreground we need to fix that bug.