### PR TITLE
Support asynchronous data zone management and some bug fixes

### DIFF
--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -170,7 +170,6 @@ class ZonedBlockDevice {
   uint32_t finish_threshold_ = 0;
 
   std::shared_ptr<BackgroundWorker> data_worker_;
-  std::list<Zone *> active_zones_list_;
   std::mutex active_zone_list_mtx_;
 
   std::atomic<int> fg_request_;

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -66,7 +66,7 @@ class Zone {
   uint64_t capacity_; /* remaining capacity */
   uint64_t max_capacity_;
   uint64_t wp_;
-  bool open_for_write_;
+  std::atomic<bool> open_for_write_;
   std::atomic<bool> bg_processing_;
   Env::WriteLifeTimeHint lifetime_;
   std::atomic<long> used_capacity_;

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -67,6 +67,7 @@ class Zone {
   uint64_t max_capacity_;
   uint64_t wp_;
   bool open_for_write_;
+  std::atomic<bool> bg_processing_;
   Env::WriteLifeTimeHint lifetime_;
   std::atomic<long> used_capacity_;
   struct zenfs_aio_ctx wr_ctx;


### PR DESCRIPTION
* Support asynchronous data zone management with useful but non-sophisticated refined methods.
* Fix the bug that would cause I/O error at extreme circumstances due to imprecise barrier management of limited I/O zone resources. 
* Fix active/opened counters' bug caused by its misinterpreted name.
* Remove redundant codes and impropriate assertions after this refactor.
