### PR TITLE
add ZenFSMetrics to ZenFS

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -272,8 +272,7 @@ IOStatus ZenFS::RollSnapshotZone(std::string* snapshot) {
   ZenMetaLog* old_snapshot_log = snapshot_log_.get();
   Zone* new_snapshot_zone;
 
-  HistReporterHandle* hist = reinterpret_cast<HistReporterHandle*>(metrics_->GetReporter(ZENFS_ROLL_QPS));
-  LatencyHistGuard guard(hist);
+  ZenFSMetricsLatencyGuard guard(metrics_, ZENFS_ROLL_QPS, Env::Default());
   metrics_->ReportQPS(ZENFS_ROLL_QPS, 1);
 
   // Close and finish old zone at first place to release active zone resources.
@@ -328,8 +327,7 @@ IOStatus ZenFS::RollMetaZoneLocked(bool async) {
   Zone* new_op_zone = nullptr;
   IOStatus s;
 
-  HistReporterHandle* hist = reinterpret_cast<HistReporterHandle*>(metrics_->GetReporter(ZENFS_ROLL_LATENCY));
-  LatencyHistGuard guard(hist);
+  ZenFSMetricsLatencyGuard guard(metrics_, ZENFS_ROLL_LATENCY, Env::Default());
   metrics_->ReportQPS(ZENFS_ROLL_QPS, 1);
 
   // reserve write pointer to the old op log to close it later
@@ -414,8 +412,7 @@ IOStatus ZenFS::PersistRecord(ZenMetaLog* meta_writer, std::string* record) {
 }
 
 IOStatus ZenFS::SyncFileMetadata(ZoneFile* zoneFile) {
-  HistReporterHandle* hist = reinterpret_cast<HistReporterHandle*>(metrics_->GetReporter(ZENFS_METADATA_SYNC_LATENCY));
-	LatencyHistGuard guard(hist);
+  ZenFSMetricsLatencyGuard guard(metrics_, ZENFS_METADATA_SYNC_LATENCY, Env::Default());
 
   std::string fileRecord;
   std::string output;

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -133,7 +133,7 @@ class ZenFS : public FileSystemWrapper {
 
   std::shared_ptr<Logger> GetLogger() { return logger_; }
 
-		std::shared_ptr<BDZenFSMetrics> metrics_;
+		std::shared_ptr<ZenFSMetrics> metrics_;
 
   struct MetadataWriter : public ZonedWritableFile::MetadataWriter {
     ZenFS* zenFS;
@@ -190,7 +190,7 @@ class ZenFS : public FileSystemWrapper {
 
  public:
   explicit ZenFS(ZonedBlockDevice* zbd, std::shared_ptr<FileSystem> aux_fs,
-                 std::shared_ptr<Logger> logger, std::shared_ptr<BytedanceMetrics> metrics);
+                 std::shared_ptr<Logger> logger, std::shared_ptr<ZenFSMetrics> metrics);
   virtual ~ZenFS();
 
   Status Mount(bool readonly, bool formating = false);

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -133,7 +133,7 @@ class ZenFS : public FileSystemWrapper {
 
   std::shared_ptr<Logger> GetLogger() { return logger_; }
 
-		std::shared_ptr<ZenFSMetrics> metrics_;
+	std::shared_ptr<ZenFSMetrics> metrics_;
 
   struct MetadataWriter : public ZonedWritableFile::MetadataWriter {
     ZenFS* zenFS;

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -265,8 +265,8 @@ ZoneExtent* ZoneFile::GetExtent(uint64_t file_offset, uint64_t* dev_offset) {
 
 IOStatus ZoneFile::PositionedRead(uint64_t offset, size_t n, Slice* result,
                                   char* scratch, bool direct) {
-  LatencyHistGuard guard(&zbd_->metrics_->read_latency_reporter_);
-  zbd_->metrics_->read_qps_reporter_.AddCount(1);
+  //LatencyHistGuard guard(&zbd_->metrics_->read_latency_reporter_);
+  zbd_->metrics_->AddRecord("zenfs_read_qps", 1);
 
 
   int f = zbd_->GetReadFD();
@@ -496,10 +496,10 @@ IOStatus ZonedWritableFile::Truncate(uint64_t size,
 IOStatus ZonedWritableFile::Fsync(const IOOptions& /*options*/,
                                   IODebugContext* /*dbg*/) {
   IOStatus s;
-  LatencyHistGuard guard(zoneFile_->is_wal_
-                             ? &zoneFile_->GetMetrics()->fg_sync_latency_reporter_
-                             : &zoneFile_->GetMetrics()->bg_sync_latency_reporter_);
-  zoneFile_->GetMetrics()->sync_qps_reporter_.AddCount(1);
+  //LatencyHistGuard guard(zoneFile_->is_wal_
+  //                       ? zoneFile_->GetMetrics()->GetRecord("fg_zenfs_sync_latency")
+  //                       : zoneFile_->GetMetrics()->GetRecord("bg_zenfs_sync_latency"));
+  zoneFile_->GetMetrics()->AddRecord("zenfs_sync_qps", 1);
 
   buffer_mtx_.lock();
   uint64_t wp0 = wp;
@@ -643,11 +643,11 @@ IOStatus ZonedWritableFile::Append(const Slice& data,
                                    const IOOptions& /*options*/,
                                    IODebugContext* /*dbg*/) {
   IOStatus s;
-  zoneFile_->GetMetrics()->write_qps_reporter_.AddCount(1);
-  zoneFile_->GetMetrics()->write_throughput_reporter_.AddCount(data.size());
-  LatencyHistGuard guard(zoneFile_->is_wal_
-                             ? &zoneFile_->GetMetrics()->fg_write_latency_reporter_
-                             : &zoneFile_->GetMetrics()->bg_write_latency_reporter_);
+  zoneFile_->GetMetrics()->AddRecord("zenfs_write_qps", 1);
+  zoneFile_->GetMetrics()->AddRecord("zenfs_write_throughput", 1);
+  //LatencyHistGuard guard(zoneFile_->is_wal_
+  //                       ? zoneFile_->GetMetrics()->GetRecord("zenfs_fg_write_latency")
+  //                       : zoneFile_->GetMetrics()->GetRecord("zenfs_bg_write_latency"));
 
   if (buffered) {
     buffer_mtx_.lock();

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -106,7 +106,7 @@ class ZoneFile {
   size_t GetUniqueId(char* id, size_t max_size);
   ZonedBlockDevice* GetZbd() { return zbd_; }
 
-		std::shared_ptr<BytedanceMetrics> GetMetrics() {return zbd_->metrics_; }
+		std::shared_ptr<ZenFSMetrics> GetMetrics() {return zbd_->metrics_; }
 };
 
 class ZonedWritableFile : public FSWritableFile {

--- a/fs/metrics.h
+++ b/fs/metrics.h
@@ -1,56 +1,7 @@
 #pragma once
-
 #include "rocksdb/env.h"
-#include "utilities/trace/bytedance_metrics_reporter.h"
-#include "zbd_stat.h"
-#include <unordered_map>
 
 namespace ROCKSDB_NAMESPACE {
-
-enum BDZenFSMetricsHistograms : uint32_t {
-  ZENFS_HISTOGRAM_ENUM_MIN, 
-
-  ZENFS_FG_WRITE_LATENCY,
-  ZENFS_BG_WRITE_LATENCY,
-  
-  ZENFS_READ_LATENCY,
-  ZENFS_FG_SYNC_LATENCY,
-  ZENFS_BG_SYNC_LATENCY,
-  ZENFS_IO_ALLOC_WAL_LATENCY,
-  ZENFS_IO_ALLOC_NON_WAL_LATENCY,
-  ZENFS_IO_ALLOC_WAL_ACTUAL_LATENCY,
-  ZENFS_IO_ALLOC_NON_WAL_ACTUAL_LATENCY,
-  ZENFS_META_ALLOC_LATENCY,
-  ZENFS_METADATA_SYNC_LATENCY,
-  ZENFS_ROLL_LATENCY,
-
-  ZENFS_WRITE_QPS,
-  ZENFS_READ_QPS,
-  ZENFS_SYNC_QPS,
-  ZENFS_IO_ALLOC_QPS,
-  ZENFS_META_ALLOC_QPS,
-  ZENFS_ROLL_QPS,
-
-  ZENFS_WRITE_THROUGHPUT,
-  ZENFS_ROLL_THROUGHPUT,
-  
-  ZENFS_ACTIVE_ZONES,
-  ZENFS_OPEN_ZONES,
-  ZENFS_FREE_SPACE,
-  ZENFS_USED_SPACE,
-  ZENFS_RECLAIMABLE_SPACE,
-  ZENFS_RESETABLE_ZONES,
-
-  ZENFS_HISTOGRAM_ENUM_MAX,
-};
-
-enum BDZenFSMetricsReporterType : uint32_t {
-  ZENFS_REPORTER_TYPE_WITHOUT_CHECK = 0,
-  ZENFS_REPORTER_TYPE_GENERAL,
-  ZENFS_REPORTER_TYPE_LATENCY,    
-  ZENFS_REPORTER_TYPE_QPS,
-  ZENFS_REPORTER_TYPE_THROUGHPUT
-};
 
 struct ZenFSMetrics {
 public:
@@ -59,13 +10,11 @@ public:
 public:
   virtual void AddReporter(uint32_t label, uint32_t type = 0) = 0;
   virtual void Report(uint32_t label, size_t value, uint32_t type_check = 0) = 0;
-public:
+public: // sugar
   virtual void ReportQPS(uint32_t label, size_t qps) = 0;
   virtual void ReportThroughput(uint32_t label, size_t throughput) = 0;
-
   virtual void ReportLatency(uint32_t label, size_t latency) = 0;
   virtual void ReportGeneral(uint32_t label, size_t data) = 0;
-  virtual void* GetReporter(uint32_t label, uint32_t type_check = 0) = 0;
   // and more
 };
 
@@ -74,171 +23,31 @@ struct NoZenFSMetrics : public ZenFSMetrics {
   virtual ~NoZenFSMetrics() {}
 public:
   virtual void AddReporter(uint32_t label, uint32_t type = 0) override {}
-  virtual void* GetReporter(uint32_t label, uint32_t type_check = 0) override { return nullptr; }
   virtual void Report(uint32_t label, size_t value, uint32_t type_check = 0) override {}
 public:
   virtual void ReportQPS(uint32_t label, size_t qps) override {}
-  virtual void ReportLatency(uint32_t label, size_t latency) override {}
   virtual void ReportThroughput(uint32_t label, size_t throughput) override {}
+  virtual void ReportLatency(uint32_t label, size_t latency) override {}
   virtual void ReportGeneral(uint32_t label, size_t data) override {}
 };
-//------------------------------
-const std::unordered_map<BDZenFSMetricsHistograms, std::string> BDZenFSHistogramsNameMap = {
-  {ZENFS_FG_WRITE_LATENCY, "zenfs_fg_write_latency"},
-  {ZENFS_BG_WRITE_LATENCY, "zenfs_bg_write_latency"},
-  {ZENFS_READ_LATENCY, "zenfs_read_latency"},
-  {ZENFS_FG_SYNC_LATENCY, "fg_zenfs_sync_latency"},
-  {ZENFS_BG_SYNC_LATENCY, "bg_zenfs_sync_latency"},
-  {ZENFS_IO_ALLOC_WAL_LATENCY, "zenfs_io_alloc_wal_latency"},
-  {ZENFS_IO_ALLOC_NON_WAL_LATENCY, "zenfs_io_alloc_non_wal_latency"},
-  {ZENFS_IO_ALLOC_WAL_ACTUAL_LATENCY, "zenfs_io_alloc_wal_actual_latency"},
-  {ZENFS_IO_ALLOC_NON_WAL_ACTUAL_LATENCY, "zenfs_io_alloc_non_wal_actual_latency"},
-  {ZENFS_META_ALLOC_LATENCY, "rzenfs_meta_alloc_latency"},
-  {ZENFS_METADATA_SYNC_LATENCY, "zenfs_metadata_sync_latency"},
-  {ZENFS_ROLL_LATENCY, "zenfs_roll_latency"},
-  {ZENFS_WRITE_QPS, "zenfs_write_qps"},
-  {ZENFS_READ_QPS, "zenfs_read_qps"},
-  {ZENFS_SYNC_QPS, "zenfs_sync_qps"},
-  {ZENFS_IO_ALLOC_QPS, "zenfs_io_alloc_qps"},
-  {ZENFS_META_ALLOC_QPS, "zenfs_meta_alloc_qps"},
-  {ZENFS_ROLL_QPS, "zenfs_roll_qps"},
-  {ZENFS_WRITE_THROUGHPUT, "rzenfs_write_throughput"},
-  {ZENFS_ROLL_THROUGHPUT, "zenfs_roll_throughput"},
-  {ZENFS_ACTIVE_ZONES, "zenfs_active_zones"},
-  {ZENFS_OPEN_ZONES, "zenfs_open_zones"},
-  {ZENFS_FREE_SPACE, "zenfs_free_space"},
-  {ZENFS_USED_SPACE, "zenfs_used_space"},
-  {ZENFS_RECLAIMABLE_SPACE, "zenfs_reclaimable_space"},
-  {ZENFS_RESETABLE_ZONES, "zenfs_resetable_zones"}
-};
 
-const std::unordered_map<BDZenFSMetricsHistograms, BDZenFSMetricsReporterType> BDZenFSHistogramsTypeMap = {
-  {ZENFS_FG_WRITE_LATENCY,            ZENFS_REPORTER_TYPE_LATENCY},
-  {ZENFS_BG_WRITE_LATENCY,            ZENFS_REPORTER_TYPE_LATENCY},
-  {ZENFS_READ_LATENCY,                ZENFS_REPORTER_TYPE_LATENCY},
-  {ZENFS_FG_SYNC_LATENCY,             ZENFS_REPORTER_TYPE_LATENCY},
-  {ZENFS_BG_SYNC_LATENCY,             ZENFS_REPORTER_TYPE_LATENCY},
-  {ZENFS_IO_ALLOC_WAL_LATENCY,        ZENFS_REPORTER_TYPE_LATENCY},
-  {ZENFS_IO_ALLOC_NON_WAL_LATENCY,    ZENFS_REPORTER_TYPE_LATENCY},
-  {ZENFS_IO_ALLOC_WAL_ACTUAL_LATENCY, ZENFS_REPORTER_TYPE_LATENCY},
-  {ZENFS_IO_ALLOC_NON_WAL_ACTUAL_LATENCY,   ZENFS_REPORTER_TYPE_LATENCY},
-  {ZENFS_META_ALLOC_LATENCY,          ZENFS_REPORTER_TYPE_LATENCY},
-  {ZENFS_METADATA_SYNC_LATENCY,       ZENFS_REPORTER_TYPE_LATENCY},
-  {ZENFS_ROLL_LATENCY,                ZENFS_REPORTER_TYPE_LATENCY},
-  {ZENFS_WRITE_QPS,                   ZENFS_REPORTER_TYPE_QPS},
-  {ZENFS_READ_QPS,                    ZENFS_REPORTER_TYPE_QPS},
-  {ZENFS_SYNC_QPS,                    ZENFS_REPORTER_TYPE_QPS},
-  {ZENFS_IO_ALLOC_QPS,                ZENFS_REPORTER_TYPE_QPS},
-  {ZENFS_META_ALLOC_QPS,              ZENFS_REPORTER_TYPE_QPS},
-  {ZENFS_ROLL_QPS,                    ZENFS_REPORTER_TYPE_QPS},
-  {ZENFS_WRITE_THROUGHPUT,            ZENFS_REPORTER_TYPE_THROUGHPUT},
-  {ZENFS_ROLL_THROUGHPUT,             ZENFS_REPORTER_TYPE_THROUGHPUT},
-  {ZENFS_ACTIVE_ZONES,                ZENFS_REPORTER_TYPE_GENERAL},
-  {ZENFS_OPEN_ZONES,                  ZENFS_REPORTER_TYPE_GENERAL},
-  {ZENFS_FREE_SPACE,                  ZENFS_REPORTER_TYPE_GENERAL},
-  {ZENFS_USED_SPACE,                  ZENFS_REPORTER_TYPE_GENERAL},
-  {ZENFS_RECLAIMABLE_SPACE,           ZENFS_REPORTER_TYPE_GENERAL},
-  {ZENFS_RESETABLE_ZONES,             ZENFS_REPORTER_TYPE_GENERAL}
-};
+struct ZenFSMetricsLatencyGuard {
+  std::shared_ptr<ZenFSMetrics> metrics_;
+  uint32_t label_;
+  Env* env_;
+  uint64_t begin_time_micro_;
 
-struct BDZenFSMetrics : public ZenFSMetrics {
-public:
-  struct Reporter {
-    void* handle_;
-    BDZenFSMetricsReporterType type_;
-    Reporter(void* handle = nullptr, BDZenFSMetricsReporterType type = ZENFS_REPORTER_TYPE_WITHOUT_CHECK) 
-      : handle_(handle), type_(type) {}
-    Reporter(const Reporter& r) : handle_(r.handle_), type_(r.type_) {}
-    ~Reporter() {}
-    HistReporterHandle* GetHistReporterHandle() const { return reinterpret_cast<HistReporterHandle*>(handle_); }
-    CountReporterHandle* GetCountReporterHandle() const { return reinterpret_cast<CountReporterHandle*>(handle_); }
-  };
-private:
-  std::string bytedance_tags_;
-  std::shared_ptr<CurriedMetricsReporterFactory> factory_;
-  std::unordered_map<BDZenFSMetricsHistograms, Reporter> reporter_map_;
-private:
-  virtual void AddReporter_(BDZenFSMetricsHistograms h, const Reporter& reporter) {
-    assert(reporter_map_.find(h) == reporter_map_.end());
-    reporter_map_[h] = reporter;
-  }
-  public:
-  virtual void AddReporter(uint32_t label_uint, uint32_t type_uint = 0) override {
-    BDZenFSMetricsHistograms label = static_cast<BDZenFSMetricsHistograms>(label_uint);
-    BDZenFSMetricsReporterType type = static_cast<BDZenFSMetricsReporterType>(type_uint);
-    assert(BDZenFSHistogramsNameMap.find(label) != BDZenFSHistogramsNameMap.end());
-    const std::string& name = BDZenFSHistogramsNameMap.find(label)->second;
-    switch (type) {
-    case ZENFS_REPORTER_TYPE_GENERAL:
-    case ZENFS_REPORTER_TYPE_LATENCY: {
-      AddReporter_(label, 
-        Reporter(factory_->BuildHistReporter(name, bytedance_tags_), type));
-    } break;
-    case ZENFS_REPORTER_TYPE_QPS:
-    case ZENFS_REPORTER_TYPE_THROUGHPUT: {
-      AddReporter_(label, 
-        Reporter(factory_->BuildCountReporter(name, bytedance_tags_), type));
-    } break;
-    default: {
-      assert(false);
-      AddReporter_(label, Reporter(nullptr, type));
-    }
-    }
-  }
-  virtual void Report(uint32_t label, size_t value, uint32_t type_check = 0) override {
-    auto p = reporter_map_.find(static_cast<BDZenFSMetricsHistograms>(label));
-    assert ( p != reporter_map_.end());
-    Reporter& r = p->second;
-    if (type_check != 0) {
-      assert(static_cast<BDZenFSMetricsReporterType>(type_check) == r.type_);
-    }
-    switch (r.type_) {
-    case ZENFS_REPORTER_TYPE_GENERAL:
-    case ZENFS_REPORTER_TYPE_LATENCY: {
-      r.GetHistReporterHandle()->AddRecord(value);
-    } break;
-    case ZENFS_REPORTER_TYPE_QPS:
-    case ZENFS_REPORTER_TYPE_THROUGHPUT: {
-      r.GetCountReporterHandle()->AddCount(value);
-    } break;
-    default: {
-      assert(false);
-    }
-    }
-  }
-  virtual void* GetReporter(uint32_t label, uint32_t type_check = 0) override {
-    auto p = reporter_map_.find(static_cast<BDZenFSMetricsHistograms>(label));
-    assert (p != reporter_map_.end());
-    Reporter& r = p->second;
-    if (type_check != 0) {
-      assert(static_cast<BDZenFSMetricsReporterType>(type_check) == r.type_);
-    }
-    return r.handle_;
-  }
-public:
-  virtual void ReportQPS(uint32_t label, size_t qps) override { 
-    Report(label, qps, ZENFS_REPORTER_TYPE_QPS); 
-  }
-  virtual void ReportLatency(uint32_t label, size_t latency) override {
-    Report(label, latency, ZENFS_REPORTER_TYPE_LATENCY);
-  }
-  virtual void ReportThroughput(uint32_t label, size_t throughput) override {
-    Report(label, throughput, ZENFS_REPORTER_TYPE_THROUGHPUT);
-  }
-  virtual void ReportGeneral(uint32_t label, size_t value) override {
-    Report(label, value, ZENFS_REPORTER_TYPE_GENERAL);
-  }
- 
- public:
-  BDZenFSMetrics(std::shared_ptr<MetricsReporterFactory> factory, std::string bytedance_tags, std::shared_ptr<Logger> logger):
-    ZenFSMetrics(),
-    bytedance_tags_(bytedance_tags),
-    factory_(new CurriedMetricsReporterFactory(factory, logger.get(), Env::Default())) {
-      for (auto &h : BDZenFSHistogramsTypeMap) 
-        AddReporter(static_cast<uint32_t>(h.first), static_cast<uint32_t>(h.second));
-    }
-  virtual ~BDZenFSMetrics() {}
-};
+  ZenFSMetricsLatencyGuard(std::shared_ptr<ZenFSMetrics> metrics, uint32_t label, Env* env)
+  : metrics_(metrics), label_(label), env_(env), begin_time_micro_(GetTime()) {}
 
+  virtual ~ZenFSMetricsLatencyGuard() {
+    uint64_t end_time_micro_ = GetTime();
+    assert(end_time_micro_ > begin_time_micro_);
+    metrics_->ReportLatency(label_, Report(end_time_micro_ - begin_time_micro_)); 
+  }
+  
+  virtual uint64_t GetTime() { return env_->NowMicros(); }
+  virtual size_t Report(size_t time) { return time; }
+};
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/fs/metrics.h
+++ b/fs/metrics.h
@@ -2,148 +2,11 @@
 
 #include "rocksdb/env.h"
 #include "utilities/trace/bytedance_metrics_reporter.h"
+#include "zbd_stat.h"
 #include <map>
 
 namespace ROCKSDB_NAMESPACE {
 
-// We need to report all metrics here, don't initialize this in other places.
-class OldBytedanceMetrics {
- public:
-  OldBytedanceMetrics(std::shared_ptr<MetricsReporterFactory> factory, std::string bytedance_tags,
-                   std::shared_ptr<Logger> logger):
-        bytedance_tags_(bytedance_tags),
-        factory_(new CurriedMetricsReporterFactory(factory, logger.get(), Env::Default())),
-
-        fg_write_latency_reporter_(*factory_->BuildHistReporter(fg_write_lat_label, bytedance_tags_)),
-        bg_write_latency_reporter_(*factory_->BuildHistReporter(bg_write_lat_label, bytedance_tags_)),
-        read_latency_reporter_(*factory_->BuildHistReporter(read_lat_label, bytedance_tags_)),
-        fg_sync_latency_reporter_(*factory_->BuildHistReporter(fg_sync_lat_label, bytedance_tags_)),
-        bg_sync_latency_reporter_(*factory_->BuildHistReporter(bg_sync_lat_label, bytedance_tags_)),
-        meta_alloc_latency_reporter_(*factory_->BuildHistReporter(meta_alloc_lat_label, bytedance_tags_)),
-        sync_metadata_reporter_(*factory_->BuildHistReporter(sync_metadata_lat_label, bytedance_tags_)),
-        io_alloc_wal_latency_reporter_(*factory_->BuildHistReporter(io_alloc_wal_lat_label, bytedance_tags_)),
-        io_alloc_wal_actual_latency_reporter_(
-            *factory_->BuildHistReporter(io_alloc_wal_actual_lat_label, bytedance_tags_)),
-        io_alloc_non_wal_latency_reporter_(
-            *factory_->BuildHistReporter(io_alloc_non_wal_lat_label, bytedance_tags_)),
-        io_alloc_non_wal_actual_latency_reporter_(
-            *factory_->BuildHistReporter(io_alloc_non_wal_actual_lat_label, bytedance_tags_)),
-        roll_latency_reporter_(*factory_->BuildHistReporter(roll_lat_label, bytedance_tags_)),
-        write_qps_reporter_(*factory_->BuildCountReporter(write_qps_label, bytedance_tags_)),
-        read_qps_reporter_(*factory_->BuildCountReporter(read_qps_label, bytedance_tags_)),
-        sync_qps_reporter_(*factory_->BuildCountReporter(sync_qps_label, bytedance_tags_)),
-        meta_alloc_qps_reporter_(*factory_->BuildCountReporter(meta_alloc_qps_label, bytedance_tags_)),
-        io_alloc_qps_reporter_(*factory_->BuildCountReporter(io_alloc_qps_label, bytedance_tags_)),
-        roll_qps_reporter_(*factory_->BuildCountReporter(roll_qps_label, bytedance_tags_)),
-        write_throughput_reporter_(*factory_->BuildCountReporter(write_throughput_label, bytedance_tags_)),
-        roll_throughput_reporter_(*factory_->BuildCountReporter(roll_throughput_label, bytedance_tags_)),
-        active_zones_reporter_(*factory_->BuildHistReporter(active_zones_label, bytedance_tags_)),
-        open_zones_reporter_(*factory_->BuildHistReporter(open_zones_label, bytedance_tags_)),
-        zbd_free_space_reporter_(*factory_->BuildHistReporter(zbd_free_space_label, bytedance_tags_)),
-        zbd_used_space_reporter_(*factory_->BuildHistReporter(zbd_used_space_label, bytedance_tags_)),
-        zbd_reclaimable_space_reporter_(
-            *factory_->BuildHistReporter(zbd_reclaimable_space_label, bytedance_tags_)),
-        zbd_resetable_zones_reporter_(*factory_->BuildHistReporter(zbd_resetable_zones_label, bytedance_tags_)) {}
-
- public:
-  std::string fg_write_lat_label = "zenfs_fg_write_latency";
-  std::string bg_write_lat_label = "zenfs_bg_write_latency";
-
-  std::string read_lat_label = "zenfs_read_latency";
-  std::string fg_sync_lat_label = "fg_zenfs_sync_latency";
-  std::string bg_sync_lat_label = "bg_zenfs_sync_latency";
-  std::string io_alloc_wal_lat_label = "zenfs_io_alloc_wal_latency";
-  std::string io_alloc_non_wal_lat_label = "zenfs_io_alloc_non_wal_latency";
-  std::string io_alloc_wal_actual_lat_label = "zenfs_io_alloc_wal_actual_latency";
-  std::string io_alloc_non_wal_actual_lat_label = "zenfs_io_alloc_non_wal_actual_latency";
-  std::string meta_alloc_lat_label = "zenfs_meta_alloc_latency";
-  std::string sync_metadata_lat_label = "zenfs_metadata_sync_latency";
-  std::string roll_lat_label = "zenfs_roll_latency";
-
-  std::string write_qps_label = "zenfs_write_qps";
-  std::string read_qps_label = "zenfs_read_qps";
-  std::string sync_qps_label = "zenfs_sync_qps";
-  std::string io_alloc_qps_label = "zenfs_io_alloc_qps";
-  std::string meta_alloc_qps_label = "zenfs_meta_alloc_qps";
-  std::string roll_qps_label = "zenfs_roll_qps";
-
-  std::string write_throughput_label = "zenfs_write_throughput";
-  std::string roll_throughput_label = "zenfs_roll_throughput";
-
-  std::string active_zones_label = "zenfs_active_zones";
-  std::string open_zones_label = "zenfs_open_zones";
-  std::string zbd_free_space_label = "zenfs_free_space";
-  std::string zbd_used_space_label = "zenfs_used_space";
-  std::string zbd_reclaimable_space_label = "zenfs_reclaimable_space";
-  std::string zbd_resetable_zones_label = "zenfs_resetable_zones";
-
- public:
-  std::string bytedance_tags_;
-  std::shared_ptr<CurriedMetricsReporterFactory> factory_;
-
-  using LatencyReporter = HistReporterHandle &;
-
-  // All reporters
-  LatencyReporter fg_write_latency_reporter_;
-  LatencyReporter bg_write_latency_reporter_;
-
-  LatencyReporter read_latency_reporter_;
-  LatencyReporter fg_sync_latency_reporter_;
-  LatencyReporter bg_sync_latency_reporter_;
-  LatencyReporter meta_alloc_latency_reporter_;
-  LatencyReporter sync_metadata_reporter_;
-  LatencyReporter io_alloc_wal_latency_reporter_;
-  LatencyReporter io_alloc_wal_actual_latency_reporter_;
-  LatencyReporter io_alloc_non_wal_latency_reporter_;
-  LatencyReporter io_alloc_non_wal_actual_latency_reporter_;
-  LatencyReporter roll_latency_reporter_;
-
-  using QPSReporter = CountReporterHandle &;
-  QPSReporter write_qps_reporter_;
-  QPSReporter read_qps_reporter_;
-  QPSReporter sync_qps_reporter_;
-  QPSReporter meta_alloc_qps_reporter_;
-  QPSReporter io_alloc_qps_reporter_;
-  QPSReporter roll_qps_reporter_;
-
-  using ThroughputReporter = CountReporterHandle &;
-  ThroughputReporter write_throughput_reporter_;
-  ThroughputReporter roll_throughput_reporter_;
-
-  using DataReporter = HistReporterHandle &;
-  DataReporter active_zones_reporter_;
-  DataReporter open_zones_reporter_;
-  DataReporter zbd_free_space_reporter_;
-  DataReporter zbd_used_space_reporter_;
-  DataReporter zbd_reclaimable_space_reporter_;
-  DataReporter zbd_resetable_zones_reporter_;
-};
-
-struct ZenFSMetrics {
-public:
-  ZenFSMetrics() {}
-  virtual ~ZenFSMetrics() {}
-public:
-  virtual void AddReporter(const std::string& label, const std::string& type = "") = 0;
-public: // For Record Reporter:
-  virtual void AddRecord(const std::string& label, size_t value) = 0;
-  virtual void* GetRecord(const std::string& label) = 0;
-};
-
-struct NoZenFSMetrics : public ZenFSMetrics {
-  NoZenFSMetrics() : ZenFSMetrics() {}
-public:
-  virtual void AddReporter(const std::string& label, const std::string& type = "") override {
-    // Do nothing.
-  }
-  virtual void AddRecord(const std::string& label, size_t value) override {
-    // Do nothing.
-  }
-  virtual void* GetRecord(const std::string& label) override {
-    return nullptr;
-    // Do nothing.
-  }
-};
 
 struct BDZenFSMetrics : public ZenFSMetrics {
 public:
@@ -262,5 +125,119 @@ public:
   std::string zbd_reclaimable_space_label = "zenfs_reclaimable_space";
   std::string zbd_resetable_zones_label = "zenfs_resetable_zones";
 };
+
+// We need to report all metrics here, don't initialize this in other places.
+class OldBytedanceMetrics {
+ public:
+  OldBytedanceMetrics(std::shared_ptr<MetricsReporterFactory> factory, std::string bytedance_tags,
+                   std::shared_ptr<Logger> logger):
+        bytedance_tags_(bytedance_tags),
+        factory_(new CurriedMetricsReporterFactory(factory, logger.get(), Env::Default())),
+
+        fg_write_latency_reporter_(*factory_->BuildHistReporter(fg_write_lat_label, bytedance_tags_)),
+        bg_write_latency_reporter_(*factory_->BuildHistReporter(bg_write_lat_label, bytedance_tags_)),
+        read_latency_reporter_(*factory_->BuildHistReporter(read_lat_label, bytedance_tags_)),
+        fg_sync_latency_reporter_(*factory_->BuildHistReporter(fg_sync_lat_label, bytedance_tags_)),
+        bg_sync_latency_reporter_(*factory_->BuildHistReporter(bg_sync_lat_label, bytedance_tags_)),
+        meta_alloc_latency_reporter_(*factory_->BuildHistReporter(meta_alloc_lat_label, bytedance_tags_)),
+        sync_metadata_reporter_(*factory_->BuildHistReporter(sync_metadata_lat_label, bytedance_tags_)),
+        io_alloc_wal_latency_reporter_(*factory_->BuildHistReporter(io_alloc_wal_lat_label, bytedance_tags_)),
+        io_alloc_wal_actual_latency_reporter_(
+            *factory_->BuildHistReporter(io_alloc_wal_actual_lat_label, bytedance_tags_)),
+        io_alloc_non_wal_latency_reporter_(
+            *factory_->BuildHistReporter(io_alloc_non_wal_lat_label, bytedance_tags_)),
+        io_alloc_non_wal_actual_latency_reporter_(
+            *factory_->BuildHistReporter(io_alloc_non_wal_actual_lat_label, bytedance_tags_)),
+        roll_latency_reporter_(*factory_->BuildHistReporter(roll_lat_label, bytedance_tags_)),
+        write_qps_reporter_(*factory_->BuildCountReporter(write_qps_label, bytedance_tags_)),
+        read_qps_reporter_(*factory_->BuildCountReporter(read_qps_label, bytedance_tags_)),
+        sync_qps_reporter_(*factory_->BuildCountReporter(sync_qps_label, bytedance_tags_)),
+        meta_alloc_qps_reporter_(*factory_->BuildCountReporter(meta_alloc_qps_label, bytedance_tags_)),
+        io_alloc_qps_reporter_(*factory_->BuildCountReporter(io_alloc_qps_label, bytedance_tags_)),
+        roll_qps_reporter_(*factory_->BuildCountReporter(roll_qps_label, bytedance_tags_)),
+        write_throughput_reporter_(*factory_->BuildCountReporter(write_throughput_label, bytedance_tags_)),
+        roll_throughput_reporter_(*factory_->BuildCountReporter(roll_throughput_label, bytedance_tags_)),
+        active_zones_reporter_(*factory_->BuildHistReporter(active_zones_label, bytedance_tags_)),
+        open_zones_reporter_(*factory_->BuildHistReporter(open_zones_label, bytedance_tags_)),
+        zbd_free_space_reporter_(*factory_->BuildHistReporter(zbd_free_space_label, bytedance_tags_)),
+        zbd_used_space_reporter_(*factory_->BuildHistReporter(zbd_used_space_label, bytedance_tags_)),
+        zbd_reclaimable_space_reporter_(
+            *factory_->BuildHistReporter(zbd_reclaimable_space_label, bytedance_tags_)),
+        zbd_resetable_zones_reporter_(*factory_->BuildHistReporter(zbd_resetable_zones_label, bytedance_tags_)) {}
+
+ public:
+  std::string fg_write_lat_label = "zenfs_fg_write_latency";
+  std::string bg_write_lat_label = "zenfs_bg_write_latency";
+
+  std::string read_lat_label = "zenfs_read_latency";
+  std::string fg_sync_lat_label = "fg_zenfs_sync_latency";
+  std::string bg_sync_lat_label = "bg_zenfs_sync_latency";
+  std::string io_alloc_wal_lat_label = "zenfs_io_alloc_wal_latency";
+  std::string io_alloc_non_wal_lat_label = "zenfs_io_alloc_non_wal_latency";
+  std::string io_alloc_wal_actual_lat_label = "zenfs_io_alloc_wal_actual_latency";
+  std::string io_alloc_non_wal_actual_lat_label = "zenfs_io_alloc_non_wal_actual_latency";
+  std::string meta_alloc_lat_label = "zenfs_meta_alloc_latency";
+  std::string sync_metadata_lat_label = "zenfs_metadata_sync_latency";
+  std::string roll_lat_label = "zenfs_roll_latency";
+
+  std::string write_qps_label = "zenfs_write_qps";
+  std::string read_qps_label = "zenfs_read_qps";
+  std::string sync_qps_label = "zenfs_sync_qps";
+  std::string io_alloc_qps_label = "zenfs_io_alloc_qps";
+  std::string meta_alloc_qps_label = "zenfs_meta_alloc_qps";
+  std::string roll_qps_label = "zenfs_roll_qps";
+
+  std::string write_throughput_label = "zenfs_write_throughput";
+  std::string roll_throughput_label = "zenfs_roll_throughput";
+
+  std::string active_zones_label = "zenfs_active_zones";
+  std::string open_zones_label = "zenfs_open_zones";
+  std::string zbd_free_space_label = "zenfs_free_space";
+  std::string zbd_used_space_label = "zenfs_used_space";
+  std::string zbd_reclaimable_space_label = "zenfs_reclaimable_space";
+  std::string zbd_resetable_zones_label = "zenfs_resetable_zones";
+
+ public:
+  std::string bytedance_tags_;
+  std::shared_ptr<CurriedMetricsReporterFactory> factory_;
+
+  using LatencyReporter = HistReporterHandle &;
+
+  // All reporters
+  LatencyReporter fg_write_latency_reporter_;
+  LatencyReporter bg_write_latency_reporter_;
+
+  LatencyReporter read_latency_reporter_;
+  LatencyReporter fg_sync_latency_reporter_;
+  LatencyReporter bg_sync_latency_reporter_;
+  LatencyReporter meta_alloc_latency_reporter_;
+  LatencyReporter sync_metadata_reporter_;
+  LatencyReporter io_alloc_wal_latency_reporter_;
+  LatencyReporter io_alloc_wal_actual_latency_reporter_;
+  LatencyReporter io_alloc_non_wal_latency_reporter_;
+  LatencyReporter io_alloc_non_wal_actual_latency_reporter_;
+  LatencyReporter roll_latency_reporter_;
+
+  using QPSReporter = CountReporterHandle &;
+  QPSReporter write_qps_reporter_;
+  QPSReporter read_qps_reporter_;
+  QPSReporter sync_qps_reporter_;
+  QPSReporter meta_alloc_qps_reporter_;
+  QPSReporter io_alloc_qps_reporter_;
+  QPSReporter roll_qps_reporter_;
+
+  using ThroughputReporter = CountReporterHandle &;
+  ThroughputReporter write_throughput_reporter_;
+  ThroughputReporter roll_throughput_reporter_;
+
+  using DataReporter = HistReporterHandle &;
+  DataReporter active_zones_reporter_;
+  DataReporter open_zones_reporter_;
+  DataReporter zbd_free_space_reporter_;
+  DataReporter zbd_used_space_reporter_;
+  DataReporter zbd_reclaimable_space_reporter_;
+  DataReporter zbd_resetable_zones_reporter_;
+};
+
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/fs/zbd_stat.h
+++ b/fs/zbd_stat.h
@@ -28,6 +28,32 @@ class ZoneStat {
   std::vector<ZoneFileStat> files;
 };
 
+struct ZenFSMetrics {
+public:
+  ZenFSMetrics() {}
+  virtual ~ZenFSMetrics() {}
+public:
+  virtual void AddReporter(const std::string& label, const std::string& type = "") = 0;
+public: // For Record Reporter:
+  virtual void AddRecord(const std::string& label, size_t value) = 0;
+  virtual void* GetRecord(const std::string& label) = 0;
+};
+
+struct NoZenFSMetrics : public ZenFSMetrics {
+  NoZenFSMetrics() : ZenFSMetrics() {}
+public:
+  virtual void AddReporter(const std::string& label, const std::string& type = "") override {
+    // Do nothing.
+  }
+  virtual void AddRecord(const std::string& label, size_t value) override {
+    // Do nothing.
+  }
+  virtual void* GetRecord(const std::string& label) override {
+    return nullptr;
+    // Do nothing.
+  }
+};
+
 }  // namespace ROCKSDB_NAMESPACE
 
 #endif  // !defined(ROCKSDB_LITE) && defined(OS_LINUX)

--- a/fs/zbd_stat.h
+++ b/fs/zbd_stat.h
@@ -28,33 +28,6 @@ class ZoneStat {
   std::vector<ZoneFileStat> files;
 };
 
-struct ZenFSMetrics {
-public:
-  ZenFSMetrics() {}
-  virtual ~ZenFSMetrics() {}
-public:
-  virtual void AddReporter(const std::string& label, const std::string& type = "") = 0;
-public: // For Record Reporter:
-  virtual void AddRecord(const std::string& label, size_t value) = 0;
-  virtual void* GetRecord(const std::string& label) = 0;
-};
-
-struct NoZenFSMetrics : public ZenFSMetrics {
-  NoZenFSMetrics() : ZenFSMetrics() {}
-  virtual ~NoZenFSMetrics() {}
-public:
-  virtual void AddReporter(const std::string& label, const std::string& type = "") override {
-    // Do nothing.
-  }
-  virtual void AddRecord(const std::string& label, size_t value) override {
-    // Do nothing.
-  }
-  virtual void* GetRecord(const std::string& label) override {
-    return nullptr;
-    // Do nothing.
-  }
-};
-
 }  // namespace ROCKSDB_NAMESPACE
 
 #endif  // !defined(ROCKSDB_LITE) && defined(OS_LINUX)

--- a/fs/zbd_stat.h
+++ b/fs/zbd_stat.h
@@ -41,6 +41,7 @@ public: // For Record Reporter:
 
 struct NoZenFSMetrics : public ZenFSMetrics {
   NoZenFSMetrics() : ZenFSMetrics() {}
+  virtual ~NoZenFSMetrics() {}
 public:
   virtual void AddReporter(const std::string& label, const std::string& type = "") override {
     // Do nothing.

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -549,23 +549,19 @@ uint64_t ZonedBlockDevice::GetReclaimableSpace() {
 void ZonedBlockDevice::ReportSpaceUtilization() {
   auto free_space = GetFreeSpace() >> 30;
   Info(logger_, "zbd free space %lu GB \n", free_space);
-  //metrics_->zbd_free_space_reporter_.AddRecord(free_space);
-  metrics_->AddRecord("zenfs_free_space", free_space);
+  metrics_->ReportGeneral(ZENFS_FREE_SPACE, free_space);
 
   auto used_space = GetUsedSpace() >> 30;
   Info(logger_, "zbd used(valid) space %lu GB\n", used_space);
-  //metrics_->zbd_used_space_reporter_.AddRecord(used_space);
-  metrics_->AddRecord("zenfs_used_space", used_space);
+  metrics_->ReportGeneral(ZENFS_USED_SPACE, used_space);
 
   auto reclaimable_space = GetReclaimableSpace() >> 30;
   Info(logger_, "zbd reclaimable space %lu GB\n", reclaimable_space);
-  //metrics_->zbd_reclaimable_space_reporter_.AddRecord(reclaimable_space);
-  metrics_->AddRecord("zenfs_reclaimable_space", reclaimable_space);
+  metrics_->ReportGeneral(ZENFS_RECLAIMABLE_SPACE, reclaimable_space);
 
   auto resetable_zones = GetResetableZones();
   Info(logger_, "zbd resetable zones %d\n", resetable_zones);
-  //metrics_->zbd_resetable_zones_reporter_.AddRecord(resetable_zones);
-  metrics_->AddRecord("zenfs_resetable_zones", resetable_zones);
+  metrics_->ReportGeneral(ZENFS_RESETABLE_ZONES, resetable_zones);
 
   // log garbage distribution
   // garbage percent: [0%, <10%, <20% ... <100%, 100%]
@@ -667,9 +663,9 @@ unsigned int GetLifeTimeDiff(Env::WriteLifeTimeHint zone_lifetime, Env::WriteLif
 }
 
 Zone *ZonedBlockDevice::AllocateMetaZone() {
-  //LatencyHistGuard guard(&(metrics_->meta_alloc_latency_reporter_));
-  //metrics_->meta_alloc_qps_reporter_.AddCount(1);
-  metrics_->AddRecord("zenfs_meta_alloc_qps", 1);
+  HistReporterHandle* hist = reinterpret_cast<HistReporterHandle*>(metrics_->GetReporter(ZENFS_META_ALLOC_LATENCY));
+  LatencyHistGuard guard(hist);
+  metrics_->ReportQPS(ZENFS_META_ALLOC_QPS, 1);
 
   for (const auto z : op_zones_) {
     if (z->IsEmpty()) {
@@ -681,9 +677,9 @@ Zone *ZonedBlockDevice::AllocateMetaZone() {
 }
 
 Zone *ZonedBlockDevice::AllocateSnapshotZone() {
-  //LatencyHistGuard guard(&(metrics_->meta_alloc_latency_reporter_));
-  //metrics_->meta_alloc_qps_reporter_.AddCount(1);
-  metrics_->AddRecord("zenfs_meta_alloc_qps", 1);
+  HistReporterHandle* hist = reinterpret_cast<HistReporterHandle*>(metrics_->GetReporter(ZENFS_META_ALLOC_LATENCY));
+  LatencyHistGuard guard(hist);
+  metrics_->ReportQPS(ZENFS_META_ALLOC_QPS, 1);
 
   for (const auto z : snapshot_zones_) {
     if (z->IsEmpty()) {
@@ -715,12 +711,10 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
   // We reserve one more free zone for WAL files in case RocksDB delay close WAL files.
   int reserved_zones = 1;
 
-  //auto *reporter = is_wal ? 
-  //  &metrics_->io_alloc_wal_latency_reporter_ : 
-  //  &metrics_->io_alloc_non_wal_latency_reporter_;
-  //LatencyHistGuard guard(reporter);
-  //metrics_->io_alloc_qps_reporter_.AddCount(1);
-  metrics_->AddRecord("zenfs_io_alloc_qps", 1);
+  HistReporterHandle* hist = reinterpret_cast<HistReporterHandle*>(metrics_->GetReporter(
+    is_wal ? ZENFS_IO_ALLOC_WAL_LATENCY : ZENFS_IO_ALLOC_NON_WAL_LATENCY));
+  LatencyHistGuard guard(hist);
+  metrics_->ReportQPS(ZENFS_IO_ALLOC_QPS, 1);
 
   auto t0 = std::chrono::system_clock::now();
 
@@ -820,10 +814,8 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
 
   auto t5 = std::chrono::system_clock::now();
 
-  //metrics_->open_zones_reporter_.AddRecord(open_io_zones_);
-  //metrics_->active_zones_reporter_.AddRecord(active_io_zones_);
-  metrics_->AddRecord("zenfs_open_zones", open_io_zones_);
-  metrics_->AddRecord("zenfs_active_zones", active_io_zones_);
+  metrics_->ReportGeneral(ZENFS_OPEN_ZONES, open_io_zones_);
+  metrics_->ReportGeneral(ZENFS_ACTIVE_ZONES, active_io_zones_);
 
   std::stringstream ss;
   ss << " is_wal = " << is_wal << " a/o zones " << active_io_zones_.load() << "," << open_io_zones_.load()

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -549,19 +549,23 @@ uint64_t ZonedBlockDevice::GetReclaimableSpace() {
 void ZonedBlockDevice::ReportSpaceUtilization() {
   auto free_space = GetFreeSpace() >> 30;
   Info(logger_, "zbd free space %lu GB \n", free_space);
-  metrics_->zbd_free_space_reporter_.AddRecord(free_space);
+  //metrics_->zbd_free_space_reporter_.AddRecord(free_space);
+  metrics_->AddRecord("zenfs_free_space", free_space);
 
   auto used_space = GetUsedSpace() >> 30;
   Info(logger_, "zbd used(valid) space %lu GB\n", used_space);
-  metrics_->zbd_used_space_reporter_.AddRecord(used_space);
+  //metrics_->zbd_used_space_reporter_.AddRecord(used_space);
+  metrics_->AddRecord("zenfs_used_space", used_space);
 
   auto reclaimable_space = GetReclaimableSpace() >> 30;
   Info(logger_, "zbd reclaimable space %lu GB\n", reclaimable_space);
-  metrics_->zbd_reclaimable_space_reporter_.AddRecord(reclaimable_space);
+  //metrics_->zbd_reclaimable_space_reporter_.AddRecord(reclaimable_space);
+  metrics_->AddRecord("zenfs_reclaimable_space", reclaimable_space);
 
   auto resetable_zones = GetResetableZones();
   Info(logger_, "zbd resetable zones %d\n", resetable_zones);
-  metrics_->zbd_resetable_zones_reporter_.AddRecord(resetable_zones);
+  //metrics_->zbd_resetable_zones_reporter_.AddRecord(resetable_zones);
+  metrics_->AddRecord("zenfs_resetable_zones", resetable_zones);
 
   // log garbage distribution
   // garbage percent: [0%, <10%, <20% ... <100%, 100%]
@@ -663,8 +667,9 @@ unsigned int GetLifeTimeDiff(Env::WriteLifeTimeHint zone_lifetime, Env::WriteLif
 }
 
 Zone *ZonedBlockDevice::AllocateMetaZone() {
-  LatencyHistGuard guard(&(metrics_->meta_alloc_latency_reporter_));
-  metrics_->meta_alloc_qps_reporter_.AddCount(1);
+  //LatencyHistGuard guard(&(metrics_->meta_alloc_latency_reporter_));
+  //metrics_->meta_alloc_qps_reporter_.AddCount(1);
+  metrics_->AddRecord("zenfs_meta_alloc_qps", 1);
 
   for (const auto z : op_zones_) {
     if (z->IsEmpty()) {
@@ -676,8 +681,9 @@ Zone *ZonedBlockDevice::AllocateMetaZone() {
 }
 
 Zone *ZonedBlockDevice::AllocateSnapshotZone() {
-  LatencyHistGuard guard(&(metrics_->meta_alloc_latency_reporter_));
-  metrics_->meta_alloc_qps_reporter_.AddCount(1);
+  //LatencyHistGuard guard(&(metrics_->meta_alloc_latency_reporter_));
+  //metrics_->meta_alloc_qps_reporter_.AddCount(1);
+  metrics_->AddRecord("zenfs_meta_alloc_qps", 1);
 
   for (const auto z : snapshot_zones_) {
     if (z->IsEmpty()) {
@@ -709,10 +715,12 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
   // We reserve one more free zone for WAL files in case RocksDB delay close WAL files.
   int reserved_zones = 1;
 
-  auto *reporter =
-      is_wal ? &metrics_->io_alloc_wal_latency_reporter_ : &metrics_->io_alloc_non_wal_latency_reporter_;
-  LatencyHistGuard guard(reporter);
-  metrics_->io_alloc_qps_reporter_.AddCount(1);
+  //auto *reporter = is_wal ? 
+  //  &metrics_->io_alloc_wal_latency_reporter_ : 
+  //  &metrics_->io_alloc_non_wal_latency_reporter_;
+  //LatencyHistGuard guard(reporter);
+  //metrics_->io_alloc_qps_reporter_.AddCount(1);
+  metrics_->AddRecord("zenfs_io_alloc_qps", 1);
 
   auto t0 = std::chrono::system_clock::now();
 
@@ -812,8 +820,10 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
 
   auto t5 = std::chrono::system_clock::now();
 
-  metrics_->open_zones_reporter_.AddRecord(open_io_zones_);
-  metrics_->active_zones_reporter_.AddRecord(active_io_zones_);
+  //metrics_->open_zones_reporter_.AddRecord(open_io_zones_);
+  //metrics_->active_zones_reporter_.AddRecord(active_io_zones_);
+  metrics_->AddRecord("zenfs_open_zones", open_io_zones_);
+  metrics_->AddRecord("zenfs_active_zones", active_io_zones_);
 
   std::stringstream ss;
   ss << " is_wal = " << is_wal << " a/o zones " << active_io_zones_.load() << "," << open_io_zones_.load()

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -28,7 +28,6 @@
 #include <utility>
 #include <vector>
 
-#include "metrics.h"
 #include "rocksdb/env.h"
 #include "rocksdb/io_status.h"
 #include "rocksdb/metrics_reporter.h"

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -180,7 +180,7 @@ class ZonedBlockDevice {
   std::mutex metazone_reset_mtx_;
   std::condition_variable metazone_reset_cv_;
 
-  std::shared_ptr<BytedanceMetrics> metrics_;
+  std::shared_ptr<ZenFSMetrics> metrics_;
 
  public:
   explicit ZonedBlockDevice(std::string bdevname, std::shared_ptr<Logger> logger);

--- a/test/utils.h
+++ b/test/utils.h
@@ -58,7 +58,7 @@ ZonedBlockDevice *zbd_open(bool readonly, std::shared_ptr<Logger> logger) {
 Status zenfs_mount(ZonedBlockDevice *zbd, ZenFS **zenFS, bool readonly, std::shared_ptr<Logger> logger) {
   Status s;
 
-  auto metrics = std::make_shared<BytedanceMetrics>(std::make_shared<ByteDanceMetricsReporterFactory>(), "", logger);
+  auto metrics = std::make_shared<BDZenFSMetrics>(std::make_shared<ByteDanceMetricsReporterFactory>(), "", logger);
   *zenFS = new ZenFS(zbd, FileSystem::Default(), logger, metrics);
   s = (*zenFS)->Mount(readonly);
   if (!s.ok()) {

--- a/test/zenfs_metazone_rollover_test.cc
+++ b/test/zenfs_metazone_rollover_test.cc
@@ -41,7 +41,7 @@ int test_mkfs() {
   }
 
   ZenFS *zenFS;
-  auto metrics = std::make_shared<BytedanceMetrics>(std::make_shared<ByteDanceMetricsReporterFactory>(), "", logger);
+  auto metrics = std::make_shared<BDZenFSMetrics>(std::make_shared<ByteDanceMetricsReporterFactory>(), "", logger);
   zenFS = new ZenFS(zbd, FileSystem::Default(), logger, metrics);
 
   if (FLAGS_aux_path.back() != '/') {

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -53,7 +53,7 @@ ZonedBlockDevice *zbd_open(bool readonly) {
 Status zenfs_mount(ZonedBlockDevice *zbd, ZenFS **zenFS, bool readonly, bool formating = false) {
   Status s;
   auto logger = std::make_shared<test::NullLogger>();
-  auto metrics = std::make_shared<BytedanceMetrics>(std::make_shared<ByteDanceMetricsReporterFactory>(), "", logger);
+  auto metrics = std::make_shared<BDZenFSMetrics>(std::make_shared<ByteDanceMetricsReporterFactory>(), "", logger);
   *zenFS = new ZenFS(zbd, FileSystem::Default(), logger, metrics);
   s = (*zenFS)->Mount(readonly, formating);
   if (!s.ok()) {
@@ -97,7 +97,7 @@ int zenfs_tool_mkfs() {
   zbd = zbd_open(false);
 
   auto logger = std::make_shared<test::NullLogger>();
-  auto metrics = std::make_shared<BytedanceMetrics>(std::make_shared<ByteDanceMetricsReporterFactory>(), "", logger);
+  auto metrics = std::make_shared<BDZenFSMetrics>(std::make_shared<ByteDanceMetricsReporterFactory>(), "", logger);
   zenFS = new ZenFS(zbd, FileSystem::Default(), logger, metrics);
 
   if (FLAGS_aux_path.back() != '/') FLAGS_aux_path.append("/");


### PR DESCRIPTION
Warning: Merging only this branch will cause the code to fail to compile.
The code of **zenfs/metrics.h** has been refactored and decoupled into two parts. The interface part of the code is still located in this file, and the rest of the implementation is located in **utilities/trace/bytedance_metrics_reporter.h**.